### PR TITLE
Added .gitignore and exposed DiskManager::CloseFileStreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+*obj/
+*.sln
+*.suo

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
@@ -146,7 +146,7 @@ namespace MonoTorrent.Client
 
         #region Methods
 
-        internal WaitHandle CloseFileStreams(TorrentManager manager)
+        public WaitHandle CloseFileStreams(TorrentManager manager)
         {
             ManualResetEvent handle = new ManualResetEvent(false);
 


### PR DESCRIPTION
The CloseFileStreams method was marked as internal, but I have found it useful to have access to in the calling assembly however, as when changing state from downloading to seeding it doesn't flush the stream, so I have to do the following to work around it:

```
        private void TorrentStateChanged(object sender, TorrentStateChangedEventArgs e)
        {
            if (e.OldState == TorrentState.Downloading && e.NewState == TorrentState.Seeding)
            {
                e.TorrentManager.Stop();
                e.TorrentManager.Engine.DiskManager.CloseFileStreams(e.TorrentManager).WaitOne();
                e.TorrentManager.Start();
            }
        }
```

In TorrentManager::RaiseTorrentStateChanged there is the following comment:

> Whenever we have a state change, we need to make sure that we flush the buffers.
> For example, Started->Paused, Started->Stopped, Downloading->Seeding etc should all 
> flush to disk.

But to do this, we need the CloseFileStreams method to be exposed. I think it would probably be better to implement the above code snippet into RaiseTorrentStateChanged itself, but not sure if you want that to be implemented outside it or not.
