### PR TITLE
Fix duplicate peer bug when peers first added after announce

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
@@ -152,7 +152,7 @@ namespace MonoTorrent.Client
                 return false;
 
             // FIXME: Don't compare the port, just compare the IP
-            if (string.IsNullOrEmpty(peerId) && string.IsNullOrEmpty(other.peerId))
+            if (string.IsNullOrEmpty(peerId) || string.IsNullOrEmpty(other.peerId))
                 return this.connectionUri.Host.Equals(other.connectionUri.Host);
 
             return peerId == other.peerId;


### PR DESCRIPTION
Prevents Available peer count from fluctuating wildly after an announce.
peerId is not set for newly returned peers immediately after Announce() is called.
Previously, this resulted in equal peers being identified as different peers.
With this change, if peerId isn't set for EITHER old or new peer, comparison by host is performed.
