### PR TITLE
Do not try to connect to ourselves as a peer.

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -36,6 +36,7 @@ using MonoTorrent.Client.Encryption;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.NetworkInformation;
 using MonoTorrent.Client.Messages;
 using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Messages.FastPeer;
@@ -641,7 +642,21 @@ namespace MonoTorrent.Client
             // Remove the peer from the lists so we can start connecting to him
             peer = manager.Peers.AvailablePeers[i];
             manager.Peers.AvailablePeers.RemoveAt(i);
-            
+
+            // Do not try to connect to ourselves
+            if (peer.ConnectionUri.Port == manager.Engine.Listener.Endpoint.Port)
+            {
+                if (manager.Engine.Listener.Endpoint.Address.ToString() == peer.ConnectionUri.Host)
+                    return false;
+
+                if (manager.Engine.Listener.Endpoint.Address == IPAddress.Any)
+                    foreach (var intf in NetworkInterface.GetAllNetworkInterfaces())
+                        if (intf.OperationalStatus == OperationalStatus.Up)
+                            foreach (var ip in intf.GetIPProperties().UnicastAddresses)
+                                if (ip.Address.ToString() == peer.ConnectionUri.Host)
+                                    return false;
+            }
+
             if (ShouldBanPeer(peer))
                 return false;
             


### PR DESCRIPTION
There is no check yet to ensure that we do not connect to ourselves as a peer. In situations where there are few peers on the network for a large number of torrents, this could lead to a max connection count exhaustion although no downloading is actually occurring.

This patch first checks whether the engine’s listening address and port are the same as the peer’s and rejects such peers. In the case where the listening address is `IpAddr.Any`, it enumerates all IP addresses of all network devices that are up, and rejects the peer if it matches one of those addresses.