### PR TITLE
Fix SpeedMonitor Tick() logic. Fixes slow peer download speed #53

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Common/SpeedMonitor.cs
+++ b/src/MonoTorrent/MonoTorrent.Common/SpeedMonitor.cs
@@ -130,11 +130,14 @@ namespace MonoTorrent.Common
         public void Tick()
         {
             DateTime old = lastUpdated;
-            lastUpdated = DateTime.UtcNow;
-            int difference = (int) (lastUpdated - old).TotalMilliseconds;
+            DateTime now = DateTime.UtcNow;
+            int difference = (int) (now - old).TotalMilliseconds;
 
             if (difference > 800)
+            {
+                lastUpdated = now;
                 TimePeriodPassed(difference);
+            }
         }
 
         // Used purely for unit testing purposes.


### PR DESCRIPTION
Only update the lastUpdated value if we actually perform a update, otherwise if Tick() is called at a fixed rate lower than 800ms the internal average is never calculated. #53