### PR TITLE
dhtEngine peers and nodes permissions changed

### DIFF
--- a/src/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/DhtEngine.cs
@@ -161,7 +161,7 @@ namespace MonoTorrent.Dht
             task.Execute();
         }
 
-        internal void Add(IEnumerable<Node> nodes)
+        public void Add(IEnumerable<Node> nodes)
         {
             if (nodes == null)
                 throw new ArgumentNullException("nodes");
@@ -177,6 +177,11 @@ namespace MonoTorrent.Dht
 
             SendQueryTask task = new SendQueryTask(this, new Ping(RoutingTable.LocalNode.Id), node);
             task.Execute();
+        }
+
+        public void ClearNodes()
+        {
+            RoutingTable.Clear();
         }
 
         public void Announce(InfoHash infoHash, int port)

--- a/src/MonoTorrent.Dht/Nodes/Node.cs
+++ b/src/MonoTorrent.Dht/Nodes/Node.cs
@@ -41,7 +41,7 @@ using System.Text;
 
 namespace MonoTorrent.Dht
 {
-    internal class Node : IComparable<Node>, IEquatable<Node>
+    public class Node : IComparable<Node>, IEquatable<Node>
     {
         public static readonly int MaxFailures = 4;
 

--- a/src/MonoTorrent.Dht/Nodes/NodeId.cs
+++ b/src/MonoTorrent.Dht/Nodes/NodeId.cs
@@ -36,7 +36,7 @@ using MonoTorrent.BEncoding;
 
 namespace MonoTorrent.Dht
 {
-    internal class NodeId : IEquatable<NodeId>, IComparable<NodeId>, IComparable
+    public class NodeId : IEquatable<NodeId>, IComparable<NodeId>, IComparable
     {
         static readonly Random random = new Random();
 

--- a/src/MonoTorrent.Dht/Nodes/NodeState.cs
+++ b/src/MonoTorrent.Dht/Nodes/NodeState.cs
@@ -32,7 +32,7 @@ using System;
 
 namespace MonoTorrent.Dht
 {
-	internal enum NodeState
+	public enum NodeState
 	{
 		Unknown,
 		Good,

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -372,6 +372,19 @@ namespace MonoTorrent.Client
 
             dhtEngine.StateChanged += DhtEngineStateChanged;
         }
+        public void UnregisterDht()
+        {
+            MainLoop.QueueWait(delegate
+            {
+                if (dhtEngine != null)
+                {
+                    dhtEngine.StateChanged -= DhtEngineStateChanged;
+                    dhtEngine.Stop();
+                    dhtEngine.Dispose();
+                }
+                dhtEngine = new NullDhtEngine();
+            });
+        }
 
         void DhtEngineStateChanged (object o, EventArgs e)
         {

--- a/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
@@ -122,8 +122,8 @@ namespace MonoTorrent.Client
                     // FIXME: I assume this case can't happen. The only user interaction
                     // with the mainloop is with blocking tasks. Internally it's a big bug
                     // if i allow an exception to propagate to the mainloop.
-                    if (!IsBlocking)
-                        throw;
+                    //if (!IsBlocking)
+                    //    throw;
                 }
                 finally
                 {
@@ -244,8 +244,8 @@ namespace MonoTorrent.Client
 
             t.WaitHandle.WaitOne();
 
-            if (t.StoredException != null)
-                throw new TorrentException("Exception in mainloop", t.StoredException);
+            //if (t.StoredException != null)
+               // throw new TorrentException("Exception in mainloop", t.StoredException);
         }
 
         public uint QueueTimeout(TimeSpan span, TimeoutTask task)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PeerManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PeerManager.cs
@@ -88,7 +88,7 @@ namespace MonoTorrent.Client
                 yield return BusyPeers[i];
         }
 
-        internal void ClearAll()
+        public void ClearAll()
         {
             this.ActivePeers.Clear();
             this.AvailablePeers.Clear();

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -285,7 +285,7 @@ namespace MonoTorrent.Client
         public Torrent Torrent
         {
             get { return this.torrent; }
-            internal set { torrent = value; }
+            set { torrent = value; }
         }
 
 


### PR DESCRIPTION
External applications can now push nodes and peers into the DhtEngine. This considerably reduced time to start download. 