### PR TITLE
Issue 102 fix leaks

### DIFF
--- a/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using MonoTorrent.Client;
@@ -133,6 +134,18 @@ namespace MonoTorrent.Client
                 Assert.IsTrue(picker.ValidatePiece(id, message.PieceIndex, message.StartOffset, message.RequestLength, out piece));
 
             Assert.IsNotNull(picker.PickPiece(id, new List<PeerId>()));
+        }
+
+        [Test]
+        public void ReceivedPiecesAreNotRequested()
+        {
+            for (int i = 2; i < pieces[0].BlockCount; i++) {
+                pieces[0].Blocks[i].CreateRequest (new PeerId (new Peer ("", new Uri ("http://asd")), null));
+                pieces[0].Blocks[i].Received = true;
+            }
+
+            picker.Initialise(bitfield, rig.Torrent.Files, pieces);
+            Assert.IsTrue (picker.Requests.All (t => !t.Block.Received), "#1");
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PeerExchangeManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PeerExchangeManager.cs
@@ -61,7 +61,6 @@ namespace MonoTorrent.Client
 			this.addedPeers = new List<Peer>();
 			this.droppedPeers = new List<Peer>();
             id.TorrentManager.OnPeerFound += new EventHandler<PeerAddedEventArgs>(OnAdd);
-            Start();
         }
 
         internal void OnAdd(object source, PeerAddedEventArgs e)
@@ -73,15 +72,6 @@ namespace MonoTorrent.Client
 
 
         #region Methods
-
-        internal void Start()
-        {
-            ClientEngine.MainLoop.QueueTimeout(TimeSpan.FromMinutes(1), delegate {
-                if (!disposed)
-                    OnTick();
-                return !disposed;
-            });
-        }
 
         internal void OnTick()
         {

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -41,9 +41,12 @@ namespace MonoTorrent.Client
                 Manager.RaiseTorrentStateChanged(new TorrentStateChangedEventArgs(Manager, TorrentState.Downloading, TorrentState.Seeding));
                 _ = Manager.TrackerManager.Announce(TorrentEvent.Completed);
             }
-            for (int i = 0; i < Manager.Peers.ConnectedPeers.Count; i++)
-                if (!ShouldConnect(Manager.Peers.ConnectedPeers[i]))
+            for (int i = 0; i < Manager.Peers.ConnectedPeers.Count; i++) {
+                if (!ShouldConnect(Manager.Peers.ConnectedPeers[i])) {
                     Manager.Engine.ConnectionManager.CleanupSocket (Manager.Peers.ConnectedPeers[i]);
+                    i--;
+                }
+            }
             base.Tick(counter);
         }
     }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -499,6 +499,11 @@ namespace MonoTorrent.Client
                 if (id.Connection == null)
                     continue;
 
+                if (!id.LastPeerExchangeReview.IsRunning || id.LastPeerExchangeReview.Elapsed > TimeSpan.FromMinutes (1)) {
+                    id.PeerExchangeManager?.OnTick ();
+                    id.LastPeerExchangeReview.Restart ();
+                }
+
                 int maxRequests = PieceManager.NormalRequestAmount + (int)(id.Monitor.DownloadSpeed / 1024.0 / PieceManager.BonusRequestPerKb);
                 maxRequests = Math.Min(id.AmRequestingPiecesCount + 2, maxRequests);
                 maxRequests = Math.Min(id.MaxSupportedPendingRequests, maxRequests);

--- a/src/MonoTorrent/MonoTorrent.Client/PeerConnections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/PeerConnections/PeerId.cs
@@ -52,6 +52,7 @@ namespace MonoTorrent.Client
         internal double LastReviewUploadRate { get; set; } = 0;
         internal bool FirstReviewPeriod { get; set; }
         internal Stopwatch LastBlockReceived { get; } = new Stopwatch ();
+        internal Stopwatch LastPeerExchangeReview { get; } = new Stopwatch ();
 
         #endregion
 

--- a/src/MonoTorrent/MonoTorrent.Client/PiecePicking/EndGamePicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/PiecePicking/EndGamePicker.cs
@@ -113,7 +113,7 @@ namespace MonoTorrent.Client
             foreach (Piece piece in pieces)
             {
                 for (int i = 0; i < piece.BlockCount; i++)
-                    if (piece.Blocks[i].RequestedOff != null)
+                    if (piece.Blocks[i].RequestedOff != null && !piece.Blocks[i].Received)
                         this.requests.Add(new Request(piece.Blocks[i].RequestedOff, piece.Blocks[i]));
             }
         }

--- a/src/MonoTorrent/MonoTorrent.Client/PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/PiecePicking/EndGameSwitcher.cs
@@ -146,6 +146,7 @@ namespace MonoTorrent.Client
 			if (inEndgame)
 			{
 				endgame.Initialise(bitfield, files, standard.ExportActiveRequests());
+				standard.Reset ();
 				// Set torrent's IsInEndGame flag
 				torrentManager.isInEndGame = true;
 			}


### PR DESCRIPTION
@OneFingerCodingWarrior There was one leak where PeerIds would be retained forever in the StandardPicker when we swapped from `StandardPicker` -> `EndGamePicker`. There was a missing call to reset the StandardPicker when the swap occurred :)