### PR TITLE
[core] Represent PeerID and TrackerID as a BEncodedString

### DIFF
--- a/src/MonoTorrent.Tests/Client/HttpTrackerTests.cs
+++ b/src/MonoTorrent.Tests/Client/HttpTrackerTests.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using MonoTorrent.BEncoding;
 using MonoTorrent.Tracker.Listeners;
 
 using NUnit.Framework;
@@ -50,17 +51,16 @@ namespace MonoTorrent.Client.Tracker
         HTTPTracker tracker;
 
         InfoHash infoHash;
-        string peerId;
-        string trackerId;
+        BEncodedString peerId;
+        BEncodedString trackerId;
 
-
-        readonly List<string> keys = new List<string> ();
+        readonly List<BEncodedString> keys = new List<BEncodedString> ();
 
         [OneTimeSetUp]
         public void FixtureSetup()
         {
-            peerId = "my peer id &&=?!<>  ";
-            trackerId = "&=?!<>   ";
+            peerId = Enumerable.Repeat ((byte)'=', 20).ToArray ();
+            trackerId = Enumerable.Repeat ((byte)'&', 20).ToArray ();
             listener = new HttpTrackerListener (ListeningPrefix);
             listener.AnnounceReceived += delegate (object o, MonoTorrent.Tracker.AnnounceParameters e) {
                 keys.Add(e.Key);

--- a/src/MonoTorrent.Tests/Client/UdpTrackerTests.cs
+++ b/src/MonoTorrent.Tests/Client/UdpTrackerTests.cs
@@ -33,6 +33,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
+using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Messages.UdpTracker;
 using MonoTorrent.Client.Tracker;
 using MonoTorrent.Tracker.Listeners;
@@ -52,12 +53,12 @@ namespace MonoTorrent.Client
         MonoTorrent.Tracker.Tracker server;
         UdpTracker tracker;
         IgnoringListener listener;
-        List<string> keys;
+        List<BEncodedString> keys;
 
         [OneTimeSetUp]
         public void FixtureSetup()
         {
-            keys = new List<string>();
+            keys = new List<BEncodedString>();
             server = new MonoTorrent.Tracker.Tracker();
             server.AllowUnregisteredTorrents = true;
             listener = new IgnoringListener(0);

--- a/src/MonoTorrent/MonoTorrent.BEncoding/BEncodedString.cs
+++ b/src/MonoTorrent/MonoTorrent.BEncoding/BEncodedString.cs
@@ -41,6 +41,9 @@ namespace MonoTorrent.BEncoding
     {
         internal static readonly BEncodedString Empty = new BEncodedString ("");
 
+        public static bool IsNullOrEmpty (BEncodedString value)
+            => (value?.TextBytes.Length ?? 0) == 0;
+
         #region Member Variables
 
         /// <summary>
@@ -100,18 +103,21 @@ namespace MonoTorrent.BEncoding
             this.textBytes = value;
         }
 
-
         public static implicit operator BEncodedString(string value)
         {
+            if (value == null)
+                return null;
+            if (value.Length == 0)
+                return Empty;
             return new BEncodedString(value);
         }
         public static implicit operator BEncodedString(char[] value)
         {
-            return new BEncodedString(value);
+            return value == null ? null : new BEncodedString(value);
         }
         public static implicit operator BEncodedString(byte[] value)
         {
-            return new BEncodedString(value);
+            return value == null ? null : new BEncodedString(value);
         }
         #endregion
 

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Diagnostics;
 
+using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Encryption;
 using MonoTorrent.Client.Messages;
@@ -107,7 +108,7 @@ namespace MonoTorrent.Client
         public ConnectionMonitor Monitor { get; }
         internal Peer Peer { get; set; }
         internal PeerExchangeManager PeerExchangeManager { get; set; }
-        public string PeerID => Peer.PeerId;
+        public BEncodedString PeerID => Peer.PeerId;
         public int PiecesSent { get; internal set; }
         public int PiecesReceived { get; internal set; }
         internal ushort Port { get; set; }

--- a/src/MonoTorrent/MonoTorrent.Client.Messages.UdpTracker/AnnounceMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages.UdpTracker/AnnounceMessage.cs
@@ -29,6 +29,7 @@
 
 using System;
 
+using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Tracker;
 
 namespace MonoTorrent.Client.Messages.UdpTracker
@@ -37,7 +38,7 @@ namespace MonoTorrent.Client.Messages.UdpTracker
     {
         private long connectionId;
         private InfoHash infoHash;  // 20
-        private string peerId; //20
+        private BEncodedString peerId; //20
         private long downloaded;
         private long left;
         private long uploaded;
@@ -93,7 +94,7 @@ namespace MonoTorrent.Client.Messages.UdpTracker
             set { numWanted = value; }
         }
 
-        public string PeerId
+        public BEncodedString PeerId
         {
             get { return peerId; }
             set { peerId = value; }
@@ -168,7 +169,7 @@ namespace MonoTorrent.Client.Messages.UdpTracker
             written += Write(buffer, written, Action);
             written += Write(buffer, written, TransactionId);
             written += Write(buffer, written, infoHash.Hash, 0, infoHash.Hash.Length);
-            written += WriteAscii(buffer, written, peerId);
+            written += Write(buffer, written, peerId.TextBytes);
             written += Write(buffer, written, downloaded);
             written += Write(buffer, written, left);
             written += Write(buffer, written, uploaded);

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/HandshakeMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/HandshakeMessage.cs
@@ -27,6 +27,8 @@
 //
 
 
+using MonoTorrent.BEncoding;
+
 namespace MonoTorrent.Client.Messages.Standard
 {
     /// <summary>
@@ -41,59 +43,43 @@ namespace MonoTorrent.Client.Messages.Standard
 
 
         #region Member Variables
+        
+        public override int ByteLength
+        {
+            get { return 68; }
+        }
+
         /// <summary>
         /// The length of the protocol string
         /// </summary>
-        public int ProtocolStringLength
-        {
-            get { return this.protocolStringLength; }
-        }
-        private int protocolStringLength;
+        public int ProtocolStringLength { get; private set; }
 
 
         /// <summary>
         /// The protocol string to send
         /// </summary>
-        public string ProtocolString
-        {
-            get { return this.protocolString; }
-        }
-        private string protocolString;
+        public string ProtocolString { get; private set; }
 
 
         /// <summary>
-        /// The infohash of the torrent
+        /// The infohash of the torrent.
         /// </summary>
-        public InfoHash InfoHash
-        {
-            get { return this.infoHash; }
-        }
-        internal InfoHash infoHash;
-
+        public InfoHash InfoHash { get; private set; }
 
         /// <summary>
-        /// The ID of the peer
+        /// The ID of the peer (20 bytes).
         /// </summary>
-        public string PeerId
-        {
-            get { return this.peerId; }
-        }
-        private string peerId;
-
-        public bool SupportsExtendedMessaging
-        {
-            get { return extended; }
-        }
-        private bool extended;
+        public BEncodedString PeerId { get; private set; }
 
         /// <summary>
-        /// True if the peer supports the Bittorrent FastPeerExtensions
+        /// True if the peer supports LibTorrent extended messaging.
         /// </summary>
-        public bool SupportsFastPeer
-        {
-            get { return this.supportsFastPeer; }
-        }
-        private bool supportsFastPeer;
+        public bool SupportsExtendedMessaging { get; private set; }
+
+        /// <summary>
+        /// True if the peer supports the Bittorrent FastPeerExtensions.
+        /// </summary>
+        public bool SupportsFastPeer { get; private set; }
         #endregion
 
 
@@ -112,19 +98,19 @@ namespace MonoTorrent.Client.Messages.Standard
             
         }
 
-        public HandshakeMessage(InfoHash infoHash, string peerId, string protocolString)
+        public HandshakeMessage(InfoHash infoHash, BEncodedString peerId, string protocolString)
             : this(infoHash, peerId, protocolString, ClientEngine.SupportsFastPeer, ClientEngine.SupportsExtended)
         {
 
         }
 
-        public HandshakeMessage(InfoHash infoHash, string peerId, string protocolString, bool enableFastPeer)
+        public HandshakeMessage(InfoHash infoHash, BEncodedString peerId, string protocolString, bool enableFastPeer)
             : this(infoHash, peerId, protocolString, enableFastPeer, ClientEngine.SupportsExtended)
         {
 
         }
 
-        public HandshakeMessage(InfoHash infoHash, string peerId, string protocolString, bool enableFastPeer, bool enableExtended)
+        public HandshakeMessage(InfoHash infoHash, BEncodedString peerId, string protocolString, bool enableFastPeer, bool enableExtended)
         {
             if (!ClientEngine.SupportsFastPeer && enableFastPeer)
                 throw new ProtocolException("The engine does not support fast peer, but fast peer was requested");
@@ -132,12 +118,12 @@ namespace MonoTorrent.Client.Messages.Standard
             if (!ClientEngine.SupportsExtended && enableExtended)
                 throw new ProtocolException("The engine does not support extended, but extended was requested");
 
-            this.infoHash = infoHash;
-            this.peerId = peerId;
-            this.protocolString = protocolString;
-            this.protocolStringLength = protocolString.Length;
-            this.supportsFastPeer = enableFastPeer;
-            this.extended = enableExtended;
+            InfoHash = infoHash;
+            PeerId = peerId;
+            ProtocolString = protocolString;
+            ProtocolStringLength = protocolString.Length;
+            SupportsFastPeer = enableFastPeer;
+            SupportsExtendedMessaging = enableExtended;
         }
         #endregion
 
@@ -147,8 +133,8 @@ namespace MonoTorrent.Client.Messages.Standard
         {
             int written = offset;
 
-            written += Write(buffer, written, (byte)protocolString.Length);
-            written += WriteAscii(buffer, written, protocolString);
+            written += Write(buffer, written, (byte)ProtocolString.Length);
+            written += WriteAscii(buffer, written, ProtocolString);
             written += Write(buffer, written, ZeroedBits);
 
             if (SupportsExtendedMessaging)
@@ -156,38 +142,34 @@ namespace MonoTorrent.Client.Messages.Standard
             if (SupportsFastPeer)
                 buffer[written - 1] |= FastPeersFlag;
 
-            written += Write(buffer, written, infoHash.Hash); 
-            written += WriteAscii(buffer, written, peerId);
+            written += Write(buffer, written, InfoHash.Hash); 
+            written += Write(buffer, written, PeerId.TextBytes);
 
             return CheckWritten(written - offset);
         }
 
         public override void Decode(byte[] buffer, int offset, int length)
         {
-            protocolStringLength = ReadByte(buffer, ref offset);                  // First byte is length
+            ProtocolStringLength = ReadByte(buffer, ref offset);                  // First byte is length
 
             // #warning Fix this hack - is there a better way of verifying the protocol string? Hack
-            if (protocolStringLength != VersionInfo.ProtocolStringV100.Length)
-                protocolStringLength = VersionInfo.ProtocolStringV100.Length;
+            if (ProtocolStringLength != VersionInfo.ProtocolStringV100.Length)
+                ProtocolStringLength = VersionInfo.ProtocolStringV100.Length;
 
-            protocolString = ReadString(buffer, ref offset, protocolStringLength);
+            ProtocolString = ReadString(buffer, ref offset, ProtocolStringLength);
             CheckForSupports(buffer, ref offset);
-            infoHash = new InfoHash(ReadBytes(buffer, ref offset, 20));
-            peerId = ReadString(buffer, ref offset, 20);
+            InfoHash = new InfoHash(ReadBytes(buffer, ref offset, 20));
+            PeerId = ReadBytes(buffer, ref offset, 20);
         }
 
         private void CheckForSupports(byte[] buffer, ref int offset)
         {
             // Increment offset first so that the indices are consistent between Encoding and Decoding
             offset += 8;
-            this.extended = (ExtendedMessagingFlag & buffer[offset - 3]) != 0;
-            this.supportsFastPeer = (FastPeersFlag & buffer[offset - 1]) != 0;
+            SupportsExtendedMessaging = (ExtendedMessagingFlag & buffer[offset - 3]) != 0;
+            SupportsFastPeer = (FastPeersFlag & buffer[offset - 1]) != 0;
         }
 
-        public override int ByteLength
-        {
-            get { return 68; }
-        }
         #endregion
 
 
@@ -201,9 +183,9 @@ namespace MonoTorrent.Client.Messages.Standard
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
             sb.Append("HandshakeMessage ");
             sb.Append(" PeerID ");
-            sb.Append(this.peerId);
+            sb.Append(PeerId.Text);
             sb.Append(" FastPeer ");
-            sb.Append(this.supportsFastPeer);
+            sb.Append(SupportsFastPeer);
             return sb.ToString();
         }
 
@@ -215,18 +197,17 @@ namespace MonoTorrent.Client.Messages.Standard
             if (msg == null)
                 return false;
 
-            if (this.infoHash != msg.infoHash)
+            if (InfoHash != msg.InfoHash)
                 return false;
 
-            return (this.peerId == msg.peerId
-                    && this.protocolString == msg.protocolString
-                    && this.supportsFastPeer == msg.supportsFastPeer);
+            return PeerId.Equals (msg.PeerId)
+                && ProtocolString == msg.ProtocolString
+                && SupportsFastPeer == msg.SupportsFastPeer;
         }
-
 
         public override int GetHashCode()
         {
-            return (this.infoHash.GetHashCode() ^ this.peerId.GetHashCode() ^ this.protocolString.GetHashCode());
+            return (InfoHash.GetHashCode() ^ PeerId.GetHashCode() ^ ProtocolString.GetHashCode());
         }
         #endregion
     }

--- a/src/MonoTorrent/MonoTorrent.Client.Tracker/AnnounceParameters.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Tracker/AnnounceParameters.cs
@@ -27,6 +27,8 @@
 //
 
 
+using MonoTorrent.BEncoding;
+
 namespace MonoTorrent.Client.Tracker
 {
     public class AnnounceParameters
@@ -37,7 +39,7 @@ namespace MonoTorrent.Client.Tracker
         public TorrentEvent ClientEvent { get; }
         public InfoHash InfoHash { get; }
         public string IPAddress { get; }
-        public string PeerId { get; }
+        public BEncodedString PeerId { get; }
         public int Port { get; }
         public bool RequireEncryption { get; }
         public bool SupportsEncryption { get; }
@@ -49,7 +51,7 @@ namespace MonoTorrent.Client.Tracker
 
         public AnnounceParameters(long bytesDownloaded, long bytesUploaded, long bytesLeft,
                            TorrentEvent clientEvent, InfoHash infoHash, bool requireEncryption,
-                           string peerId, string ipAddress, int port, bool supportsEncryption)
+                           BEncodedString peerId, string ipAddress, int port, bool supportsEncryption)
         {
             BytesDownloaded = bytesDownloaded;
             BytesUploaded = bytesUploaded;
@@ -81,7 +83,7 @@ namespace MonoTorrent.Client.Tracker
         public AnnounceParameters WithIPAddress (string ipAddress)
             => ipAddress == IPAddress ? this : new AnnounceParameters (BytesDownloaded, BytesUploaded, BytesLeft, ClientEvent, InfoHash, RequireEncryption, PeerId, ipAddress, Port, SupportsEncryption);
 
-        public AnnounceParameters WithPeerId (string peerId)
+        public AnnounceParameters WithPeerId (BEncodedString peerId)
             => peerId == PeerId ? this : new AnnounceParameters (BytesDownloaded, BytesUploaded, BytesLeft, ClientEvent, InfoHash, RequireEncryption, peerId, IPAddress, Port, SupportsEncryption);
 
         public AnnounceParameters WithPort (int port)

--- a/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
@@ -46,7 +46,7 @@ namespace MonoTorrent.Client.Tracker
 
         internal string TrackerId { get; set; }
 
-        internal string Key { get; set; }
+        internal BEncodedString Key { get; set; }
 
         internal TimeSpan RequestTimeout { get; set; } = DefaultRequestTimeout;
 
@@ -129,7 +129,7 @@ namespace MonoTorrent.Client.Tracker
         {
             UriQueryBuilder b = new UriQueryBuilder (Uri);
             b.Add ("info_hash", parameters.InfoHash.UrlEncode ())
-             .Add ("peer_id", parameters.PeerId.UrlEncode ())
+             .Add ("peer_id", UriHelper.UrlEncode (parameters.PeerId.TextBytes))
              .Add ("port", parameters.Port)
              .Add ("uploaded", parameters.BytesUploaded)
              .Add ("downloaded", parameters.BytesDownloaded)
@@ -142,7 +142,7 @@ namespace MonoTorrent.Client.Tracker
             if (parameters.RequireEncryption)
                 b.Add ("requirecrypto", 1);
             if (!b.Contains ("key") && Key != null)
-                b.Add ("key", Key.UrlEncode ());
+                b.Add ("key", UriHelper.UrlEncode (Key.TextBytes));
             if (!string.IsNullOrEmpty (parameters.IPAddress))
                 b.Add ("ip", parameters.IPAddress);
 

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -34,7 +34,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-
+using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Listeners;
 using MonoTorrent.Client.PieceWriters;
 using MonoTorrent.Client.RateLimiters;
@@ -113,7 +113,7 @@ namespace MonoTorrent.Client
 
         public bool IsRunning { get; private set; }
 
-        public string PeerId { get; }
+        public BEncodedString PeerId { get; }
 
         public EngineSettings Settings { get; }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -320,7 +320,7 @@ namespace MonoTorrent.Client
                     id.TorrentManager.Peers.ActivePeers.Remove(id.Peer);
 
                 // If we get our own details, this check makes sure we don't try connecting to ourselves again
-                if (canReuse && id.Peer.PeerId != engine.PeerId)
+                if (canReuse && !engine.PeerId.Equals (id.Peer.PeerId))
                 {
                     if (!id.TorrentManager.Peers.AvailablePeers.Contains(id.Peer) && id.Peer.CleanedUpCount < 5)
                         id.TorrentManager.Peers.AvailablePeers.Insert(0, id.Peer);
@@ -360,7 +360,7 @@ namespace MonoTorrent.Client
             try
             {
                 bool maxAlreadyOpen = OpenConnections >= Math.Min(this.MaxOpenConnections, id.TorrentManager.Settings.MaxConnections);
-                if (id.Peer.PeerId == engine.PeerId || maxAlreadyOpen)
+                if (engine.PeerId.Equals (id.Peer.PeerId) || maxAlreadyOpen)
                 {
                     CleanupSocket (id, "Connection was not accepted");
                     return;

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
@@ -144,7 +144,7 @@ namespace MonoTorrent.Client
                 return false;
 
             for (int i = 0; i < Engine.Torrents.Count; i++)
-                if (message.infoHash == Engine.Torrents[i].InfoHash)
+                if (message.InfoHash == Engine.Torrents[i].InfoHash)
                     man = Engine.Torrents[i];
 
             // We're not hosting that torrent

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -144,7 +144,7 @@ namespace MonoTorrent.Client
 
             // If we got the peer as a "compact" peer, then the peerid will be empty. In this case
             // we just copy the one that is in the handshake. 
-            if (string.IsNullOrEmpty(id.Peer.PeerId))
+            if (BEncodedString.IsNullOrEmpty(id.Peer.PeerId))
                 id.Peer.PeerId = message.PeerId;
 
             // If the infohash doesn't match, dump the connection
@@ -155,7 +155,7 @@ namespace MonoTorrent.Client
             }
 
             // If the peer id's don't match, dump the connection. This is due to peers faking usually
-            if (id.Peer.PeerId != message.PeerId)
+            if (!id.Peer.PeerId.Equals (message.PeerId))
             {
                 Logger.Log(id.Connection, "HandShake.Handle - Invalid peerid");
                 throw new TorrentException("Supplied PeerID didn't match the one the tracker gave us");

--- a/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
@@ -48,7 +48,7 @@ namespace MonoTorrent.Client
         private int localPort;
         private int totalHashFails;
         private bool isSeeder;
-        private string peerId;
+        private BEncodedString peerId;
         private int repeatedHashFails;
 
         #endregion Private Fields
@@ -78,7 +78,7 @@ namespace MonoTorrent.Client
             get { return this.totalHashFails; }
         }
 
-        internal string PeerId
+        internal BEncodedString PeerId
         {
             get { return peerId; }
             set { peerId = value; }
@@ -144,7 +144,7 @@ namespace MonoTorrent.Client
                 return false;
 
             // FIXME: Don't compare the port, just compare the IP
-            if (string.IsNullOrEmpty(peerId) || string.IsNullOrEmpty(other.peerId))
+            if (BEncodedString.IsNullOrEmpty (PeerId) || BEncodedString.IsNullOrEmpty(other.peerId))
                 return this.connectionUri.Host.Equals(other.connectionUri.Host);
 
             return peerId == other.peerId;

--- a/src/MonoTorrent/MonoTorrent.Tracker.Listeners/UdpTrackerListener.cs
+++ b/src/MonoTorrent/MonoTorrent.Tracker.Listeners/UdpTrackerListener.cs
@@ -193,7 +193,7 @@ namespace MonoTorrent.Tracker.Listeners
         {
             NameValueCollection res = new NameValueCollection();
             res.Add("info_hash", announceMessage.Infohash.UrlEncode());
-            res.Add("peer_id", announceMessage.PeerId);
+            res.Add("peer_id", UriHelper.UrlEncode (announceMessage.PeerId.TextBytes));
             res.Add("port", announceMessage.Port.ToString());
             res.Add("uploaded", announceMessage.Uploaded.ToString());
             res.Add("downloaded", announceMessage.Downloaded.ToString());

--- a/src/MonoTorrent/MonoTorrent.Tracker/AnnounceParameters.cs
+++ b/src/MonoTorrent/MonoTorrent.Tracker/AnnounceParameters.cs
@@ -91,9 +91,9 @@ namespace MonoTorrent.Tracker
             get { return infoHash; }
         }
 
-        public string Key
+        public BEncodedString Key
         {
-            get { return Parameters["key"]?.UrlDecode (); }
+            get { return Parameters["key"] == null ? null : UriHelper.UrlDecode (Parameters["key"]); }
         }
 
         public override bool IsValid

--- a/src/MonoTorrent/MonoTorrent/PeerID.cs
+++ b/src/MonoTorrent/MonoTorrent/PeerID.cs
@@ -29,6 +29,7 @@
 
 
 using System.Text.RegularExpressions;
+using MonoTorrent.BEncoding;
 
 namespace MonoTorrent
 {
@@ -119,7 +120,7 @@ namespace MonoTorrent
         static readonly Regex shadows = new Regex(@"(([A-Za-z]{1})\d{3})----*");
         static readonly Regex xbt = new Regex("XBT/d/{3}");
         private ClientApp client;
-        private string peerId;
+        private BEncodedString peerId;
         private string shortId;
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace MonoTorrent
         /// The peer's ID
         /// </summary>
         /// <value>The peer id.</value>
-        internal string PeerId
+        internal BEncodedString PeerId
         {
             get { return this.peerId; }
         }
@@ -154,20 +155,21 @@ namespace MonoTorrent
         /// Initializes a new instance of the <see cref="Software"/> class.
         /// </summary>
         /// <param name="peerId">The peer id.</param>
-        internal Software(string peerId)
+        internal Software(BEncodedString peerId)
         {
             Match m;
 
             this.peerId = peerId;
-			if (peerId.StartsWith("-WebSeed-"))
-			{
-				this.shortId = "WebSeed";
-				this.client = ClientApp.WebSeed;
-				return;
-			}
+            var idAsText = peerId.Text;
+            if (idAsText.StartsWith("-WebSeed-", System.StringComparison.Ordinal))
+            {
+                this.shortId = "WebSeed";
+                this.client = ClientApp.WebSeed;
+                return;
+            }
 
             #region Standard style peers
-            if ((m = standard.Match(peerId)).Success)
+            if ((m = standard.Match(idAsText)).Success)
             {
                 this.shortId = m.Groups[1].Value;
                 switch (m.Groups[2].Value)
@@ -318,7 +320,7 @@ namespace MonoTorrent
             #endregion
 
             #region Shadows Style
-            if ((m = shadows.Match(peerId)).Success)
+            if ((m = shadows.Match(idAsText)).Success)
             {
                 this.shortId = m.Groups[1].Value;
                 switch (m.Groups[2].Value)
@@ -356,7 +358,7 @@ namespace MonoTorrent
             #endregion
 
             #region Brams Client
-            if ((m = brahms.Match(peerId)).Success)
+            if ((m = brahms.Match(idAsText)).Success)
             {
                 this.shortId = "M";
                 this.client = ClientApp.BitTorrent;
@@ -365,7 +367,7 @@ namespace MonoTorrent
             #endregion
 
             #region BitLord
-            if ((m = bitlord.Match(peerId)).Success)
+            if ((m = bitlord.Match(idAsText)).Success)
             {
                 this.client = ClientApp.BitLord;
                 this.shortId = "lord";
@@ -374,7 +376,7 @@ namespace MonoTorrent
             #endregion
 
             #region BitComet
-            if ((m = bitcomet.Match(peerId)).Success)
+            if ((m = bitcomet.Match(idAsText)).Success)
             {
                 this.client = ClientApp.BitComet;
                 this.shortId = "BC";
@@ -383,7 +385,7 @@ namespace MonoTorrent
             #endregion
 
             #region XBT
-            if ((m = xbt.Match(peerId)).Success)
+            if ((m = xbt.Match(idAsText)).Success)
             {
                 this.client = ClientApp.XBTClient;
                 this.shortId = "XBT";
@@ -392,7 +394,7 @@ namespace MonoTorrent
             #endregion
 
             #region Opera
-            if ((m = opera.Match(peerId)).Success)
+            if ((m = opera.Match(idAsText)).Success)
             {
                 this.client = ClientApp.Opera;
                 this.shortId = "OP";
@@ -400,7 +402,7 @@ namespace MonoTorrent
             #endregion
 
             #region MLDonkey
-            if ((m = mldonkey .Match(peerId)).Success)
+            if ((m = mldonkey .Match(idAsText)).Success)
             {
                 this.client = ClientApp.MLDonkey;
                 this.shortId = "ML";
@@ -409,7 +411,7 @@ namespace MonoTorrent
             #endregion
 
             #region Bits on wheels
-            if ((m = bow.Match(peerId)).Success)
+            if ((m = bow.Match(idAsText)).Success)
             {
                 this.client = ClientApp.BitsOnWheels;
                 this.shortId = "BOW";
@@ -418,7 +420,7 @@ namespace MonoTorrent
             #endregion
 
             #region Queen Bee
-            if ((m = queenbee.Match(peerId)).Success)
+            if ((m = queenbee.Match(idAsText)).Success)
             {
                 this.client = ClientApp.QueenBee;
                 this.shortId = "Q";
@@ -427,7 +429,7 @@ namespace MonoTorrent
             #endregion
 
             #region BitTornado special style
-            if((m = bittornado.Match(peerId)).Success)
+            if((m = bittornado.Match(idAsText)).Success)
             {
                 this.shortId = m.Groups[1].Value;
                 this.client = ClientApp.BitTornado;
@@ -436,7 +438,7 @@ namespace MonoTorrent
             #endregion
 
             this.client = ClientApp.Unknown;
-            this.shortId = peerId;
+            this.shortId = idAsText;
         }
 
 

--- a/src/MonoTorrent/MonoTorrent/VersionInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/VersionInfo.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Reflection;
+using MonoTorrent.BEncoding;
 
 namespace MonoTorrent
 {


### PR DESCRIPTION
This can be arbitrary bytes, but must be exactly 20 bytes in length.
As such we should treat it as a BEncodedString and not like ascii
text.