### PR TITLE
Use a random seed for generating peer id

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -471,7 +471,7 @@ namespace MonoTorrent.Client
         }
 
 
-        static int count;
+        static int peerIdSeed;
         static BEncodedString GeneratePeerId()
         {
             StringBuilder sb = new StringBuilder(20);
@@ -479,7 +479,13 @@ namespace MonoTorrent.Client
             sb.Append(VersionInfo.ClientVersion);
             sb.Append ("-");
 
-            var random = new Random(count++);
+            if (peerIdSeed == 0)
+            {
+                var seedRandom = new Random();
+                peerIdSeed = seedRandom.Next();
+            }
+
+            var random = new Random(peerIdSeed++);
             while (sb.Length < 20)
                 sb.Append(random.Next(0, 9));
 


### PR DESCRIPTION
1st PR here. If there's something you'd like done differently, let me know.

The same peer id is always generated (`-MO1000-676515838224`) because `Random` is always seeded with 0 for the 1st `ClientEngine`. This prevents a monotorrent client from being able to connect to other monotorrent clients. Instead, set the 1st random seed randomly and increment from there for addition ClientEngines