### PR TITLE
Do not download

### DIFF
--- a/src/MonoTorrent.Tests/Client/FastResumeTests.cs
+++ b/src/MonoTorrent.Tests/Client/FastResumeTests.cs
@@ -1,0 +1,115 @@
+﻿//
+// FastResumeTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using MonoTorrent.BEncoding;
+using MonoTorrent.Client.Connections;
+using MonoTorrent.Client.Messages.Standard;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Client
+{
+    [TestFixture]
+    public class FastResumeTests
+    {
+        static readonly InfoHash InfoHash = new InfoHash (new byte[20]);
+
+        [Test]
+        public void AllHashed_AllDownloaded ()
+        {
+            var unhashedPieces = new  BitField (10).SetAll (false);
+            var downloaded = new  BitField (10).SetAll (true);
+            Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
+        }
+
+        [Test]
+        public void AllHashed_NothingDownloaded ()
+        {
+            var unhashedPieces = new  BitField (10).SetAll (false);
+            var downloaded = new  BitField (10).SetAll (false);
+            Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
+        }
+
+        [Test]
+        public void NoneHashed_NothingDownloaded ()
+        {
+            var unhashedPieces = new  BitField (10).SetAll (true);
+            var downloaded = new  BitField (10).SetAll (false);
+            Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
+        }
+
+        [Test]
+        public void NoneHashed_AllDownloaded ()
+        {
+            var unhashedPieces = new  BitField (10).SetAll (true);
+            var downloaded = new  BitField (10).SetAll (true);
+            Assert.Throws<ArgumentException> (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
+        }
+
+        [Test]
+        public void LoadV1FastResumeData ()
+        {
+            var v1Data = new BEncodedDictionary {
+                { FastResume.VersionKey, (BEncodedNumber)1 },
+                { FastResume.InfoHashKey, new BEncodedString(InfoHash.Hash) },
+                { FastResume.BitfieldKey, new BEncodedString(new BitField (10).SetAll (true).ToByteArray ()) },
+                { FastResume.BitfieldLengthKey, (BEncodedNumber)10 },
+            };
+
+            // If this is a v1 FastResume data then it comes from a version of MonoTorrent which always
+            // hashes the entire file.
+            var fastResume = new FastResume (v1Data);
+            Assert.IsTrue (fastResume.UnhashedPieces.AllFalse, "#1");
+            Assert.IsTrue (fastResume.Bitfield.AllTrue, "#2");
+        }
+
+        [Test]
+        public void LoadV2FastResumeData ()
+        {
+            var v1Data = new BEncodedDictionary {
+                { FastResume.VersionKey, (BEncodedNumber)1 },
+                { FastResume.InfoHashKey, new BEncodedString(InfoHash.Hash) },
+                { FastResume.BitfieldKey, new BEncodedString(new BitField (10).SetAll (false).Set (0, true).ToByteArray ()) },
+                { FastResume.BitfieldLengthKey, (BEncodedNumber)10 },
+                { FastResume.UnhashedPiecesKey, new BEncodedString (new BitField (10).SetAll (true).Set (0, false).ToByteArray ()) },
+            };
+
+            // If this is a v1 FastResume data then it comes from a version of MonoTorrent which always
+            // hashes the entire file.
+            var fastResume = new FastResume (v1Data);
+            Assert.AreEqual (1, fastResume.Bitfield.TrueCount, "#1");
+            Assert.AreEqual (9, fastResume.UnhashedPieces.TrueCount, "#2");
+        }
+
+    }
+}

--- a/src/MonoTorrent.Tests/Client/TestWebSeed.cs
+++ b/src/MonoTorrent.Tests/Client/TestWebSeed.cs
@@ -86,6 +86,7 @@ namespace MonoTorrent.Client
 
             connection = new HttpConnection(new Uri(ListenerURL));
             connection.Manager = rig.Manager;
+            rig.Manager.UnhashedPieces.SetAll (false);
 
             id = new PeerId(new Peer("this is my id", connection.Uri), connection, rig.Manager.Bitfield?.Clone ().SetAll (false));
             id.IsChoking = false;
@@ -332,6 +333,7 @@ namespace MonoTorrent.Client
             string url = rig.Torrent.GetRightHttpSeeds[0];
             connection = new HttpConnection(new Uri (url));
             connection.Manager = rig.Manager;
+            rig.Manager.UnhashedPieces.SetAll (false);
 
             id = new PeerId(new Peer("this is my id", connection.Uri), id.Connection, rig.Manager.Bitfield?.Clone ().SetAll (false));
             id.IsChoking = false;

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -127,6 +127,21 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public void SaveLoadFastResume ()
+        {
+            Manager.Bitfield.SetAll (true).Set (0, false);
+            Manager.UnhashedPieces.SetAll (false).Set (0, true);
+            Manager.HashChecked = true;
+
+            var origUnhashed = Manager.UnhashedPieces.Clone ();
+            var origBitfield = Manager.Bitfield.Clone ();
+            Manager.LoadFastResume (Manager.SaveFastResume ());
+
+            Assert.AreEqual (origUnhashed, Manager.UnhashedPieces, "#3");
+            Assert.AreEqual (origBitfield, Manager.Bitfield, "#4");
+        }
+
+        [Test]
         public async Task DoNotDownload_All ()
         {
             Manager.Bitfield.SetAll (true);
@@ -222,7 +237,7 @@ namespace MonoTorrent.Client.Modes
             });
 
             var bf = Manager.Bitfield.Clone ().SetAll (true);
-            Manager.LoadFastResume(new FastResume(Manager.InfoHash, bf));
+            Manager.LoadFastResume(new FastResume(Manager.InfoHash, bf, Manager.UnhashedPieces.SetAll (false)));
 
             Assert.IsTrue (Manager.Bitfield.AllTrue, "#1");
             foreach (TorrentFile file in Manager.Torrent.Files)

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -166,6 +166,12 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task DoNotDownload_ThenDownload ()
         {
+            DiskManager.GetHashAsyncOverride = (manager, index) => {
+                if (index >= 0 && index <= 4)
+                    return Manager.Torrent.Pieces.ReadHash (index);
+
+                return Enumerable.Repeat ((byte)255, 20).ToArray ();
+            };
             Manager.Bitfield.SetAll (true);
 
             foreach (var f in Manager.Torrent.Files) {
@@ -196,6 +202,8 @@ namespace MonoTorrent.Client.Modes
             // These pieces should now be available for download
             Manager.PieceManager.AddPieceRequests (Peer);
             Assert.AreNotEqual (0, Peer.AmRequestingPiecesCount, "#4");
+
+            Assert.AreEqual (5, Manager.finishedPieces.Count, "#5");
         }
 
         [Test]

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
@@ -50,6 +50,7 @@ namespace MonoTorrent.Client.Modes
         {
             Rig = TestRig.CreateSingleFile(Piece.BlockSize * 20, Piece.BlockSize * 2);
             Rig.Manager.Bitfield.Not ();
+            Rig.Manager.UnhashedPieces.SetAll (false);
             Rig.Manager.Mode = new InitialSeedingMode(Rig.Manager, Rig.Engine.DiskManager, Rig.Engine.ConnectionManager, Rig.Engine.Settings);
         }
 

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -140,7 +140,7 @@ namespace MonoTorrent.Client.Modes
         public async Task FastResume_NoneExist()
         {
             var bf = Manager.Bitfield.Clone ().SetAll (true);
-            Manager.LoadFastResume (new FastResume (Manager.InfoHash, bf));
+            Manager.LoadFastResume (new FastResume (Manager.InfoHash, bf, Manager.UnhashedPieces.SetAll (false)));
 
             Assert.IsTrue (Manager.Bitfield.AllTrue, "#1");
             foreach (TorrentFile file in Manager.Torrent.Files)
@@ -163,7 +163,7 @@ namespace MonoTorrent.Client.Modes
                 Manager.Torrent.Files [2],
             });
             var bf = Manager.Bitfield.Clone ().SetAll (true);
-            Manager.LoadFastResume(new FastResume(Manager.InfoHash, bf));
+            Manager.LoadFastResume(new FastResume(Manager.InfoHash, bf, Manager.UnhashedPieces.SetAll (false)));
 
             Assert.IsTrue (Manager.Bitfield.AllTrue, "#1");
             foreach (TorrentFile file in Manager.Torrent.Files)

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IgnoringPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IgnoringPicker.cs
@@ -47,9 +47,13 @@ namespace MonoTorrent.Client.PiecePicking
         {
             // Invert 'bitfield' and AND it with the peers bitfield
             // Any pieces which are 'true' in the bitfield will not be downloaded
+            if (Bitfield.AllFalse)
+                return base.PickPiece(peer, available, otherPeers, count, startIndex, endIndex);
+
             Temp.From(available).NAnd(Bitfield);
             if (Temp.AllFalse)
                 return null;
+
             return base.PickPiece(peer, Temp, otherPeers, count, startIndex, endIndex);
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
@@ -213,8 +213,13 @@ namespace MonoTorrent.Client
             return false;
         }
 
+        internal Func<ITorrentData, int, byte[]> GetHashAsyncOverride;
+
         internal async Task<byte[]> GetHashAsync(ITorrentData manager, int pieceIndex)
         {
+            if (GetHashAsyncOverride != null)
+                return GetHashAsyncOverride (manager, pieceIndex);
+
             await IOLoop;
 
             if (IncrementalHashes.TryGetValue (pieceIndex, out IncrementalHashData incrementalHash)) {

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -134,6 +134,11 @@ namespace MonoTorrent.Client
 			}
         }
 
+        /// <summary>
+        /// If <see cref="TorrentFile.Priority"/> is set to <see cref="Priority.DoNotDownload"/> then the pieces
+        /// associated with that <see cref="TorrentFile"/> will not be hash checked. An IgnoringPicker is used
+        /// to ensure pieces which have not been hash checked are never downloaded.
+        /// </summary>
         internal BitField UnhashedPieces { get; set; }
 
         internal int PeerReviewRoundsComplete
@@ -762,6 +767,7 @@ namespace MonoTorrent.Client
 
             for (int i = 0; i < Torrent.Pieces.Count; i++)
                 OnPieceHashed (i, data.Bitfield[i]);
+            UnhashedPieces.From (data.UnhashedPieces);
 
             this.HashChecked = true;
         }
@@ -771,7 +777,7 @@ namespace MonoTorrent.Client
             CheckMetadata();
             if (!HashChecked)
                 throw new InvalidOperationException ("Fast resume data cannot be created when the TorrentManager has not been hash checked");
-            return new FastResume(InfoHash, this.Bitfield);
+            return new FastResume(InfoHash, Bitfield, UnhashedPieces);
         }
 
         internal void SetTrackerManager (ITrackerManager manager)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -134,6 +134,8 @@ namespace MonoTorrent.Client
 			}
         }
 
+        internal BitField UnhashedPieces { get; set; }
+
         internal int PeerReviewRoundsComplete
         {
             get
@@ -144,7 +146,6 @@ namespace MonoTorrent.Client
                     return 0;
             }
         }
-
 
         public bool HashChecked { get; internal set; }
 
@@ -331,6 +332,7 @@ namespace MonoTorrent.Client
         void Initialise(string savePath, string baseDirectory, IList<RawTrackerTier> announces)
         {
             this.Bitfield = new BitField(HasMetadata ? Torrent.Pieces.Count : 1);
+            this.UnhashedPieces = new BitField(HasMetadata ? Torrent.Pieces.Count : 1).SetAll (true);
             this.SavePath = Path.Combine(savePath, baseDirectory);
             this.finishedPieces = new Queue<HaveMessage>();
             this.Monitor = new ConnectionMonitor();
@@ -372,8 +374,7 @@ namespace MonoTorrent.Client
         internal void ChangePicker(PiecePicker picker)
         {
             Check.Picker(picker);
-
-           PieceManager.ChangePicker(picker, Bitfield, Torrent);
+            PieceManager.ChangePicker(new IgnoringPicker (UnhashedPieces, picker), Bitfield, Torrent);
         }
 
         /// <summary>
@@ -461,6 +462,11 @@ namespace MonoTorrent.Client
 
             CheckRegisteredAndDisposed();
             StartTime = DateTime.Now;
+
+            // An IgnoringPicker is created to ensure pieces which *have not* been hash checked
+            // are not requested from other peers. The intention is that files marked as DoNotDownload
+            // will not be hashed, or downloaded.
+            UnhashedPieces.SetAll (true);
 
             var hashingMode = new HashingMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
             Mode = hashingMode;
@@ -678,6 +684,9 @@ namespace MonoTorrent.Client
         internal void OnPieceHashed(int index, bool hashPassed)
         {
             Bitfield[index] = hashPassed;
+            // The PiecePickers will no longer ignore this piece as it has now been hash checked.
+            UnhashedPieces[index] = false;
+
             TorrentFile[] files = this.Torrent.Files;
             
             for (int i = 0; i < files.Length; i++)
@@ -738,6 +747,7 @@ namespace MonoTorrent.Client
             picker = new RandomisedPicker(picker);
             picker = new RarestFirstPicker(picker);
             picker = new PriorityPicker(picker);
+
             return picker;
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -35,8 +35,6 @@ namespace MonoTorrent.Client.Modes
 {
     class HashingMode : Mode
     {
-        CancellationTokenSource Cancellation { get; }
-
         public override bool CanHashCheck => false;
 
         TaskCompletionSource<object> PausedCompletionSource { get; set; }
@@ -47,7 +45,6 @@ namespace MonoTorrent.Client.Modes
             : base (manager, diskManager, connectionManager, settings)
         {
             CanAcceptConnections = false;
-            Cancellation = new CancellationTokenSource();
 
             // Mark it as completed so we are *not* paused by default;
             PausedCompletionSource = new TaskCompletionSource<object> ();
@@ -110,8 +107,5 @@ namespace MonoTorrent.Client.Modes
         {
             // Do not run any of the default 'Tick' logic as nothing happens during 'Hashing' mode, except for hashing.
         }
-
-        public override void Dispose ()
-            => Cancellation.Cancel ();
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -205,12 +205,13 @@ namespace MonoTorrent.Client.Modes
 
         private void SwitchToRegular()
         {
-            Torrent torrent = Manager.Torrent;
             foreach (PeerId id in new List<PeerId> (Manager.Peers.ConnectedPeers))
                 Manager.Engine.ConnectionManager.CleanupSocket (Manager, id);
-            Manager.Bitfield = new BitField(torrent.Pieces.Count);
-            Manager.PieceManager.ChangePicker(Manager.CreateStandardPicker(), Manager.Bitfield, torrent);
-            foreach (TorrentFile file in torrent.Files)
+            Manager.Bitfield = new BitField(Manager.Torrent.Pieces.Count);
+            Manager.UnhashedPieces = new BitField(Manager.Torrent.Pieces.Count).SetAll (true);
+
+            Manager.ChangePicker(Manager.CreateStandardPicker());
+            foreach (TorrentFile file in Manager.Torrent.Files)
                 file.FullPath = Path.Combine (Manager.SavePath, file.Path);
             _ = Manager.StartAsync();
         }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -709,6 +709,9 @@ namespace MonoTorrent.Client.Modes
                                 var hash = await DiskManager.GetHashAsync(Manager.Torrent, index);
                                 var hashPassed = hash != null && Manager.Torrent.Pieces.IsValid(hash, index);
                                 Manager.OnPieceHashed (index, hashPassed);
+
+                                if (hashPassed)
+                                    Manager.finishedPieces.Enqueue(new HaveMessage (index));
                             }
                         }
                     }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -707,6 +707,8 @@ namespace MonoTorrent.Client.Modes
                         for (int index = file.StartPieceIndex; index <= file.EndPieceIndex; index ++) {
                             if (Manager.UnhashedPieces [index]) {
                                 var hash = await DiskManager.GetHashAsync(Manager.Torrent, index);
+                                Cancellation.Token.ThrowIfCancellationRequested ();
+
                                 var hashPassed = hash != null && Manager.Torrent.Pieces.IsValid(hash, index);
                                 Manager.OnPieceHashed (index, hashPassed);
 

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -28,19 +28,21 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Messages;
 using MonoTorrent.Client.Messages.FastPeer;
-using MonoTorrent.Client.Messages.Standard;
 using MonoTorrent.Client.Messages.Libtorrent;
-using MonoTorrent.Client.PiecePicking;
+using MonoTorrent.Client.Messages.Standard;
 
 namespace MonoTorrent.Client.Modes
 {
     abstract class Mode
     {
 
+        protected CancellationTokenSource Cancellation { get; }
         protected ConnectionManager ConnectionManager { get; }
         protected DiskManager DiskManager { get; }
         protected TorrentManager Manager { get; }
@@ -49,6 +51,7 @@ namespace MonoTorrent.Client.Modes
 
         protected Mode(TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
         {
+            Cancellation = new CancellationTokenSource ();
             CanAcceptConnections = true;
             ConnectionManager = connectionManager;
             DiskManager = diskManager;
@@ -713,9 +716,9 @@ namespace MonoTorrent.Client.Modes
             Manager.finishedPieces.Clear();
         }
 
-        public virtual void Dispose ()
+        public void Dispose ()
         {
-            // There's nothing to cancel when this mode ends.
+            Cancellation.Cancel ();
         }
     }
 }


### PR DESCRIPTION
- [x] Skip hashing files marked as DoNotDownload during startup
- [x] Do not request pieces from files marked as DoNotDownload
- [x] If a file's priority changes from DoNotDownload -> Normal, hash it and allow it to be downloaded
- [x] Handle cancellation
- [x] Handle errors while hashing
- [x] Ensure HaveMessages are sent (as appropriate).
- [x] Integrate with FastResume data.