### PR TITLE
[core] Add a PartialProgress public property

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -31,6 +31,8 @@ namespace MonoTorrent.Client.Modes
 {
     class DownloadMode : Mode
     {
+        BitField PartialProgressUpdater;
+
         TorrentState state;
 		public override TorrentState State
 		{
@@ -41,7 +43,11 @@ namespace MonoTorrent.Client.Modes
             : base (manager, diskManager, connectionManager, settings)
         {
             manager.HashFails = 0;
+
+            // Ensure the state is correct. We should either be downloading or seeding based on
+            // the files whose priority is not set to 'DoNotDownload'.
             state = manager.Complete ? TorrentState.Seeding : TorrentState.Downloading;
+            UpdateSeedingDownloadingState ();
         }
 
         public override void HandlePeerConnected(PeerId id)
@@ -58,20 +64,56 @@ namespace MonoTorrent.Client.Modes
 
         public override void Tick(int counter)
         {
-            //If download is complete, set state to 'Seeding'
-            if (Manager.Complete && state == TorrentState.Downloading)
-            {
-                state = TorrentState.Seeding;
-                Manager.RaiseTorrentStateChanged(new TorrentStateChangedEventArgs(Manager, TorrentState.Downloading, TorrentState.Seeding));
-                _ = Manager.TrackerManager.Announce(TorrentEvent.Completed);
-            }
+            base.Tick(counter);
+
+            UpdateSeedingDownloadingState ();
+
             for (int i = 0; i < Manager.Peers.ConnectedPeers.Count; i++) {
                 if (!ShouldConnect(Manager.Peers.ConnectedPeers[i])) {
                     ConnectionManager.CleanupSocket (Manager, Manager.Peers.ConnectedPeers[i]);
                     i--;
                 }
             }
-            base.Tick(counter);
+        }
+
+        
+        internal void UpdatePartialProgress ()
+        {
+            if (PartialProgressUpdater == null || PartialProgressUpdater.Length != Manager.Bitfield.Length)
+                PartialProgressUpdater = new BitField (Manager.Bitfield.Length);
+
+            PartialProgressUpdater.SetAll (false);
+            if (Manager.Torrent != null) {
+                foreach (var file in Manager.Torrent.Files) {
+                    if (file.Priority != Priority.DoNotDownload) {
+                        for (int i = file.StartPieceIndex; i <= file.EndPieceIndex; i ++)
+                            PartialProgressUpdater [i] = true;
+                    }
+                }
+            }
+            Manager.PartialProgressSelector.From (PartialProgressUpdater);
+        }
+
+        internal void UpdateSeedingDownloadingState ()
+        {
+            UpdatePartialProgress ();
+
+            //If download is fully complete, set state to 'Seeding' and send an announce to the tracker.
+            if (Manager.Complete && state == TorrentState.Downloading)  {
+                state = TorrentState.Seeding;
+                Manager.RaiseTorrentStateChanged(new TorrentStateChangedEventArgs(Manager, TorrentState.Downloading, TorrentState.Seeding));
+                _ = Manager.TrackerManager.Announce(TorrentEvent.Completed);
+            } else if (Manager.PartialProgressSelector.TrueCount > 0) {
+                // If some files are marked as DoNotDownload and we have downloaded all downloadable files, mark the torrent as 'seeding'.
+                // Otherwise if we have not downloaded all downloadable files, set the state to Downloading.
+                if (Manager.Bitfield.CountTrue (Manager.PartialProgressSelector) == Manager.PartialProgressSelector.TrueCount && state == TorrentState.Downloading) {
+                    state = TorrentState.Seeding;
+                    Manager.RaiseTorrentStateChanged(new TorrentStateChangedEventArgs(Manager, TorrentState.Downloading, TorrentState.Seeding));
+                } else if (Manager.Bitfield.CountTrue (Manager.PartialProgressSelector) < Manager.PartialProgressSelector.TrueCount && state == TorrentState.Seeding) {
+                    state = TorrentState.Seeding;
+                    Manager.RaiseTorrentStateChanged(new TorrentStateChangedEventArgs(Manager, TorrentState.Downloading, TorrentState.Seeding));
+                }
+            }
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -208,6 +208,7 @@ namespace MonoTorrent.Client.Modes
             foreach (PeerId id in new List<PeerId> (Manager.Peers.ConnectedPeers))
                 Manager.Engine.ConnectionManager.CleanupSocket (Manager, id);
             Manager.Bitfield = new BitField(Manager.Torrent.Pieces.Count);
+            Manager.PartialProgressSelector = new BitField (Manager.Torrent.Pieces.Count);
             Manager.UnhashedPieces = new BitField(Manager.Torrent.Pieces.Count).SetAll (true);
 
             Manager.ChangePicker(Manager.CreateStandardPicker());

--- a/src/MonoTorrent/MonoTorrent/BitField.cs
+++ b/src/MonoTorrent/MonoTorrent/BitField.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace MonoTorrent
@@ -290,6 +291,17 @@ namespace MonoTorrent
                 yield return Get(i);
         }
 
+        internal int CountTrue (BitField selector)
+        {
+            if (selector.Length != Length)
+                throw new ArgumentException ("The selector should be the same length as this bitfield");
+
+            uint count = 0;
+            for (int i = 0; i < array.Length; i++)
+                count += CountBits ((uint) (array [i] & selector.array [i]));
+            return (int) count;
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
@@ -417,13 +429,16 @@ namespace MonoTorrent
             // Update the population count
             uint count = 0;
             for (int i = 0; i < array.Length; i++)
-            {
-                uint v = (uint)array[i];
-                v = v - ((v >> 1) & 0x55555555);
-                v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-                count += (((v + (v >> 4) & 0xF0F0F0F) * 0x1010101)) >> 24;
-            }
+                count += CountBits ((uint)array[i]);
             trueCount = (int)count ;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static uint CountBits (uint v)
+        {
+            v = v - ((v >> 1) & 0x55555555);
+            v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+            return (((v + (v >> 4) & 0xF0F0F0F) * 0x1010101)) >> 24;
         }
 
         void ZeroUnusedBits()


### PR DESCRIPTION
When some files are marked as DoNotDownload then this property
tracks the completion rate for the files which are marked as
downloadable.

If all downloadable files have been downloaded, the state will
change to 'Seeding' without telling the tracker the download has
completed.

If files which used to be marked as 'DoNotDownload' are then marked
as downloadable, the state will change back to Downloading.