### PR TITLE
Vastly reduce allocations from async/await infrastructure

### DIFF
--- a/src/MonoTorrent.Tests/Client/DiskManagerExceptionTests.cs
+++ b/src/MonoTorrent.Tests/Client/DiskManagerExceptionTests.cs
@@ -163,14 +163,14 @@ namespace MonoTorrent.Client
         public void ReadFail()
         {
             writer.read = true;
-            Assert.ThrowsAsync<Exception> (() => diskManager.ReadAsync (data, 0, buffer, buffer.Length));
+            Assert.ThrowsAsync<Exception> (() => diskManager.ReadAsync (data, 0, buffer, buffer.Length).AsTask ());
         }
 
         [Test]
         public void WriteFail()
         {
             writer.write = true;
-            Assert.ThrowsAsync<Exception> (() => diskManager.WriteAsync(data, 0, buffer, buffer.Length));
+            Assert.ThrowsAsync<Exception> (() => diskManager.WriteAsync(data, 0, buffer, buffer.Length).AsTask ());
         }
     }
 }

--- a/src/MonoTorrent.Tests/Client/EncryptorFactoryTests.cs
+++ b/src/MonoTorrent.Tests/Client/EncryptorFactoryTests.cs
@@ -43,8 +43,8 @@ namespace MonoTorrent.Client.Encryption
     public class EncryptorFactoryTests
     {
         ConnectionPair pair;
-        IConnection Incoming => pair.Incoming;
-        IConnection Outgoing => pair.Outgoing;
+        IConnection2 Incoming => pair.Incoming;
+        IConnection2 Outgoing => pair.Outgoing;
 
         InfoHash InfoHash;
         InfoHash[] SKeys;

--- a/src/MonoTorrent.Tests/Client/NetworkIOTests.cs
+++ b/src/MonoTorrent.Tests/Client/NetworkIOTests.cs
@@ -125,7 +125,7 @@ namespace MonoTorrent.Client
                 sent += r;
             }
 
-            Assert.IsTrue (task.Wait(TimeSpan.FromSeconds (10)), "Data should be all received");
+            Assert.DoesNotThrowAsync (() => task.WithTimeout (TimeSpan.FromSeconds (10)), "Data should be all received");
             for (int i = 0; i < buffer.Length; i++) {
                 if (data[i] != buffer[i])
                     Assert.Fail ("Buffers differ at position " + i);
@@ -197,7 +197,7 @@ namespace MonoTorrent.Client
                 Assert.AreNotEqual (0, r, "#Received data");
                 received += r;
             }
-            Assert.IsTrue (task.Wait (TimeSpan.FromSeconds (1)), "Data should be all sent");
+            Assert.DoesNotThrowAsync (() => task.WithTimeout (TimeSpan.FromSeconds (1)), "Data should be all sent");
             Assert.IsTrue (Toolbox.ByteMatch (buffer, data), "Data matches");
         }
 
@@ -209,7 +209,7 @@ namespace MonoTorrent.Client
             var receiveTask = NetworkIO.ReceiveAsync(Incoming, data, 0, data.Length, null, null, null);
 
             var sendTask = NetworkIO.SendAsync (Outgoing, data, 0, data.Length, null, null, null);
-            Assert.ThrowsAsync<Exception> (() => receiveTask);
+            Assert.ThrowsAsync<Exception> (async () => await receiveTask);
             await sendTask;
         }
 
@@ -221,7 +221,7 @@ namespace MonoTorrent.Client
             var task = NetworkIO.SendAsync (Incoming, data, 0, data.Length, null, null, null);
 
             _ = NetworkIO.ReceiveAsync (Outgoing, data, 0, data.Length, null, null, null);
-            Assert.ThrowsAsync<Exception> (() => task);
+            Assert.ThrowsAsync<Exception> (async () => await task);
         }
     }
 }

--- a/src/MonoTorrent.Tests/Client/PeerIOTests.cs
+++ b/src/MonoTorrent.Tests/Client/PeerIOTests.cs
@@ -64,8 +64,8 @@ namespace MonoTorrent.Client
             await NetworkIO.SendAsync (pair.Outgoing, buffer, 0, buffer.Length);
             var receiveTask = PeerIO.ReceiveMessageAsync (pair.Incoming, PlainTextEncryption.Instance);
 
-            Assert.ThrowsAsync<ProtocolException> (() => receiveTask, "#1");
-            Assert.ThrowsAsync<Exception> (() => PeerIO.ReceiveMessageAsync (pair.Outgoing, PlainTextEncryption.Instance), "#2");
+            Assert.ThrowsAsync<ProtocolException> (async () => await receiveTask, "#1");
+            Assert.ThrowsAsync<Exception> (async () => await PeerIO.ReceiveMessageAsync (pair.Outgoing, PlainTextEncryption.Instance), "#2");
         }
 
         [Test]
@@ -77,8 +77,8 @@ namespace MonoTorrent.Client
             await NetworkIO.SendAsync (pair.Outgoing, buffer, 0, buffer.Length);
             var receiveTask = PeerIO.ReceiveMessageAsync (pair.Incoming, PlainTextEncryption.Instance);
 
-            Assert.ThrowsAsync<ProtocolException> (() => receiveTask, "#1");
-            Assert.ThrowsAsync<Exception> (() => PeerIO.ReceiveMessageAsync (pair.Outgoing, PlainTextEncryption.Instance), "#2");
+            Assert.ThrowsAsync<ProtocolException> (async () => await receiveTask, "#1");
+            Assert.ThrowsAsync<Exception> (async () => await PeerIO.ReceiveMessageAsync (pair.Outgoing, PlainTextEncryption.Instance), "#2");
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace MonoTorrent.Client
             var task = PeerIO.ReceiveMessageAsync (pair.Incoming, PlainTextEncryption.Instance, null, null, null);
             await NetworkIO.SendAsync(pair.Outgoing, data, 0, 20, null, null, null);
 
-            Assert.ThrowsAsync <ProtocolException> (() => task, "#1");
+            Assert.ThrowsAsync <ProtocolException> (async () => await task, "#1");
         }
 
         [Test]

--- a/src/MonoTorrent.Tests/Client/SocketConnectionTests.cs
+++ b/src/MonoTorrent.Tests/Client/SocketConnectionTests.cs
@@ -63,7 +63,7 @@ namespace MonoTorrent.Client
         [Test]
         public async Task DisposeWhileReceiving ()
         {
-            var task = Incoming.ReceiveAsync (new byte[100], 0, 100);
+            var task = Incoming.ReceiveAsync (new byte[100], 0, 100).AsTask ();
             Incoming.Dispose ();
 
             // All we care about is that the task is marked as 'Complete'.
@@ -75,7 +75,7 @@ namespace MonoTorrent.Client
         [Test]
         public async Task DisposeWhileSending ()
         {
-            var task = Incoming.SendAsync (new byte[1000000], 0, 1000000);
+            var task = Incoming.SendAsync (new byte[1000000], 0, 1000000).AsTask ();
             Incoming.Dispose ();
 
             // All we care about is that the task is marked as 'Complete'.

--- a/src/MonoTorrent.Tests/Client/SocketConnectionTests.cs
+++ b/src/MonoTorrent.Tests/Client/SocketConnectionTests.cs
@@ -31,7 +31,9 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+
 using MonoTorrent.Client.Connections;
+using ReusableTasks;
 
 using NUnit.Framework;
 

--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -41,6 +41,7 @@ using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Listeners;
 using MonoTorrent.Client.PieceWriters;
 using MonoTorrent.Client.Tracker;
+using ReusableTasks;
 
 namespace MonoTorrent.Client
 {

--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -142,7 +142,7 @@ namespace MonoTorrent.Client
         }
     }
 
-    public class CustomConnection : IConnection
+    public class CustomConnection : IConnection2
     {
         public byte[] AddressBytes => ((IPEndPoint)EndPoint).Address.GetAddressBytes();
         public bool CanReconnect => false;
@@ -168,7 +168,10 @@ namespace MonoTorrent.Client
             IsIncoming = isIncoming;
         }
         
-        public Task ConnectAsync()
+        Task IConnection.ConnectAsync()
+            => throw new InvalidOperationException();
+
+        public ReusableTask ConnectAsync()
             => throw new InvalidOperationException();
 
         public void Dispose()
@@ -178,7 +181,10 @@ namespace MonoTorrent.Client
             Connected = false;
         }
 
-        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.ReceiveAsync(byte[] buffer, int offset, int count)
+            => await ReceiveAsync (buffer, offset, count);
+
+        public async ReusableTask<int> ReceiveAsync(byte[] buffer, int offset, int count)
         {
             if (SlowConnection)
                 count = Math.Min(88, count);
@@ -188,7 +194,10 @@ namespace MonoTorrent.Client
             return ManualBytesReceived ?? result;
         }
 
-        public async Task<int> SendAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.SendAsync (byte[] buffer, int offset, int count)
+            => await SendAsync (buffer, offset, count);
+
+        public async ReusableTask<int> SendAsync(byte[] buffer, int offset, int count)
         {
             if (SlowConnection)
                 count = Math.Min(88, count);

--- a/src/MonoTorrent.Tests/Client/TestWebSeed.cs
+++ b/src/MonoTorrent.Tests/Client/TestWebSeed.cs
@@ -106,7 +106,7 @@ namespace MonoTorrent.Client
         [Test]
         public void Cancel_ReceiveFirst ()
         {
-            var task = connection.ReceiveAsync (new byte[100], 0, 100);
+            var task = connection.ReceiveAsync (new byte[100], 0, 100).AsTask ();
             connection.Dispose ();
             Assert.CatchAsync<OperationCanceledException> (() => task);
         }
@@ -114,7 +114,7 @@ namespace MonoTorrent.Client
         [Test]
         public void Cancel_SendFirst ()
         {
-            var task = connection.SendAsync (new MessageBundle (requests).Encode (), 0, requests.ByteLength);
+            var task = connection.SendAsync (new MessageBundle (requests).Encode (), 0, requests.ByteLength).AsTask ();
             connection.Dispose ();
             Assert.CatchAsync<OperationCanceledException> (() => task);
         }
@@ -122,7 +122,7 @@ namespace MonoTorrent.Client
         [Test]
         public void Cancel_SendAndReceiveFirst ()
         {
-            var sendTask = connection.SendAsync (new MessageBundle (requests).Encode (), 0, requests.ByteLength);
+            var sendTask = connection.SendAsync (new MessageBundle (requests).Encode (), 0, requests.ByteLength).AsTask ();
             var receiveTask = connection.ReceiveAsync (new byte[100000], 0, 100000);
             connection.Dispose ();
             Assert.CatchAsync<OperationCanceledException> (() => sendTask, "#1");

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;

--- a/src/MonoTorrent.Tests/SocketStream.cs
+++ b/src/MonoTorrent.Tests/SocketStream.cs
@@ -1,4 +1,33 @@
-﻿using System;
+﻿//
+// SocketStream.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;

--- a/src/MonoTorrent.Tests/TaskExtensions.cs
+++ b/src/MonoTorrent.Tests/TaskExtensions.cs
@@ -1,5 +1,37 @@
-﻿using System;
+﻿//
+// TaskExtensions.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
 using System.Threading.Tasks;
+
+using ReusableTasks;
+
 using NUnit.Framework;
 
 namespace MonoTorrent
@@ -7,6 +39,15 @@ namespace MonoTorrent
     public static class TaskExtensions
     {
         static readonly TimeSpan Timeout = System.Diagnostics.Debugger.IsAttached ? TimeSpan.FromHours (1) : TimeSpan.FromSeconds (5);
+
+        public static Task WithTimeout (this ReusableTask task, string message = null)
+            => task.AsTask ().WithTimeout (Timeout, message);
+
+        public static Task WithTimeout (this ReusableTask task, int timeout, string message = null)
+            => task.AsTask ().WithTimeout (timeout, message);
+
+        public static Task WithTimeout (this ReusableTask task, TimeSpan timeout, string message = null)
+            => task.AsTask ().WithTimeout (timeout, message);
 
         public static Task WithTimeout (this Task task, string message = null)
             => task.WithTimeout (Timeout, message);
@@ -24,6 +65,12 @@ namespace MonoTorrent
                 throw new TimeoutException ("This is just to keep the compiler happy :p");
             }
         }
+
+        public static Task<T> WithTimeout<T> (this ReusableTask<T> task, string message = null)
+            => task.AsTask ().WithTimeout (message);
+
+        public static Task<T> WithTimeout<T> (this ReusableTask<T> task, int timeout, string message = null)
+            => task.AsTask ().WithTimeout (TimeSpan.FromMilliseconds (timeout), message);
 
         public static Task<T> WithTimeout<T> (this Task<T> task, string message = null)
             => task.WithTimeout (Timeout, message);

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/ConnectionConverter.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/ConnectionConverter.cs
@@ -1,0 +1,88 @@
+﻿//
+// ConnectionConverter.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+using ReusableTasks;
+
+namespace MonoTorrent.Client.Connections
+{
+    static class ConnectionConverter
+    {
+        public static IConnection2 Convert (IConnection connection)
+        {
+            if (connection is IConnection2 v2)
+                return v2;
+            return new V1ToV2Converter (connection);
+        }
+    }
+
+    class V1ToV2Converter : IConnection2
+    {
+        IConnection Connection { get; }
+
+        public byte [] AddressBytes => Connection.AddressBytes;
+
+        public bool Connected => Connection.Connected;
+
+        public bool CanReconnect => Connection.CanReconnect;
+
+        public bool IsIncoming => Connection.IsIncoming;
+
+        public EndPoint EndPoint => Connection.EndPoint;
+
+        public Uri Uri => Connection.Uri;
+
+        public V1ToV2Converter (IConnection connection)
+            => Connection = connection;
+
+        public async ReusableTask ConnectAsync ()
+            => await Connection.ConnectAsync ();
+
+        public async ReusableTask<int> ReceiveAsync (byte [] buffer, int offset, int count)
+            => await Connection.ReceiveAsync (buffer, offset, count);
+
+        public async ReusableTask<int> SendAsync (byte [] buffer, int offset, int count)
+            => await Connection.SendAsync (buffer, offset, count);
+
+        Task IConnection.ConnectAsync ()
+            => Connection.ConnectAsync ();
+
+        Task<int> IConnection.ReceiveAsync (byte [] buffer, int offset, int count)
+            => Connection.ReceiveAsync (buffer, offset, count);
+
+        Task<int> IConnection.SendAsync (byte [] buffer, int offset, int count)
+            =>  Connection.SendAsync (buffer, offset, count);
+
+        public void Dispose ()
+            => Connection.Dispose ();
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/ConnectionFactory.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/ConnectionFactory.cs
@@ -64,7 +64,7 @@ namespace MonoTorrent.Client.Connections
         public static IConnection Create(Uri connectionUri)
         {
             if (connectionUri == null)
-                throw new ArgumentNullException("connectionUrl");
+                throw new ArgumentNullException(nameof (connectionUri));
 
             if (connectionUri.Scheme == "ipv4" && connectionUri.Port == -1)
                 return null;

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/HTTPConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/HTTPConnection.cs
@@ -40,7 +40,7 @@ using ReusableTasks;
 
 namespace MonoTorrent.Client.Connections
 {
-    sealed class HttpConnection : IConnection
+    sealed class HttpConnection : IConnection2
     {
         class HttpRequestData
         {
@@ -116,13 +116,18 @@ namespace MonoTorrent.Client.Connections
 
         #endregion Constructors
 
+        Task IConnection.ConnectAsync ()
+            => Task.CompletedTask;
 
-        public Task ConnectAsync()
+        public ReusableTask ConnectAsync ()
         {
-            return Task.CompletedTask;
+            return ReusableTask.CompletedTask;
         }
 
-        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.ReceiveAsync (byte[] buffer, int offset, int count)
+            => await ReceiveAsync (buffer, offset, count);
+
+        public async ReusableTask<int> ReceiveAsync (byte[] buffer, int offset, int count)
         {
             // This is a little tricky, so let's spell it out in comments...
             if (Disposed)
@@ -240,7 +245,10 @@ namespace MonoTorrent.Client.Connections
             throw new WebException ("Unable to download the required data from the server");
         }
 
-        public async Task<int> SendAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.SendAsync (byte[] buffer, int offset, int count)
+            => await SendAsync (buffer, offset, count);
+
+        public async ReusableTask<int> SendAsync (byte[] buffer, int offset, int count)
         {
             SendResult = new TaskCompletionSource<object>();
 

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/HTTPConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/HTTPConnection.cs
@@ -36,6 +36,7 @@ using System.Threading.Tasks;
 
 using MonoTorrent.Client.Messages;
 using MonoTorrent.Client.Messages.Standard;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Connections
 {

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/IConnection2.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/IConnection2.cs
@@ -1,10 +1,10 @@
 //
-// IEncryptor.cs
+// IConnection2.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
 //
-// Copyright (C) 2006 Alan McGovern
+// Copyright (C) 2019 Alan McGovern
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -27,18 +27,16 @@
 //
 
 
-using MonoTorrent.Client.Connections;
 using ReusableTasks;
 
-namespace MonoTorrent.Client.Encryption
+namespace MonoTorrent.Client.Connections
 {
-    interface IEncryptor
+    public interface IConnection2 : IConnection
     {
-        ReusableTask HandshakeAsync(IConnection2 socket);
+        new ReusableTask ConnectAsync();
 
-        ReusableTask HandshakeAsync(IConnection2 socket, byte[] initialBuffer, int offset, int count);
+        new ReusableTask<int> ReceiveAsync (byte[] buffer, int offset, int count);
 
-        IEncryption Encryptor { get; }
-        IEncryption Decryptor { get; }
-    }
+        new ReusableTask<int> SendAsync (byte[] buffer, int offset, int count);
+	}
 }

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -41,7 +41,7 @@ namespace MonoTorrent.Client
     public partial class PeerId
     {
         /// <summary>
-        /// Creates a PeerID with a null TorrentManager and IConnection. This is used for unit testing purposes.
+        /// Creates a PeerID with a null TorrentManager and IConnection2. This is used for unit testing purposes.
         /// The peer will have <see cref="ProcessingQueue"/>, <see cref="IsChoking"/> and <see cref="AmChoking"/>
         /// set to true. A bitfield with all pieces set to <see langword="false"/> will be created too.
         /// </summary>
@@ -61,7 +61,7 @@ namespace MonoTorrent.Client
 
         internal long BytesDownloadedAtLastReview { get; set; } = 0;
         internal long BytesUploadedAtLastReview { get; set; } = 0;
-        internal IConnection Connection { get; }
+        internal IConnection2 Connection { get; }
         internal double LastReviewDownloadRate { get; set; } = 0;
         internal double LastReviewUploadRate { get; set; } = 0;
         internal bool FirstReviewPeriod { get; set; }
@@ -159,7 +159,9 @@ namespace MonoTorrent.Client
         internal PeerId(Peer peer, IConnection connection, BitField bitfield)
             : this (peer)
         {
-            Connection = connection ?? throw new ArgumentNullException (nameof (connection));
+            if (connection == null)
+                throw new ArgumentNullException (nameof (connection));
+            Connection = ConnectionConverter.Convert (connection);
             Peer = peer ?? throw new ArgumentNullException (nameof (peer));
             BitField = bitfield;
         }

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
@@ -33,6 +33,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
+using ReusableTasks;
+
 namespace MonoTorrent.Client.Connections
 {
     class SocketConnection : IConnection
@@ -99,6 +101,10 @@ namespace MonoTorrent.Client.Connections
 
         public bool IsIncoming { get; }
 
+        ReusableTaskCompletionSource<int> ReceiveTcs { get; }
+
+        ReusableTaskCompletionSource<int> SendTcs { get; }
+
         Socket Socket { get; set; }
 
         public Uri Uri { get; protected set; }
@@ -124,6 +130,8 @@ namespace MonoTorrent.Client.Connections
 
         SocketConnection (Socket socket, IPEndPoint endpoint, bool isIncoming)
         {
+            ReceiveTcs = new ReusableTaskCompletionSource<int> ();
+            SendTcs = new ReusableTaskCompletionSource<int> ();
             Socket = socket;
             EndPoint = endpoint;
             IsIncoming = isIncoming;
@@ -133,7 +141,7 @@ namespace MonoTorrent.Client.Connections
         {
             // Don't retain the TCS forever. Note we do not want to null out the byte[] buffer
             // as we *do* want to retain that so that we can avoid the expensive SetBuffer calls.
-            var tcs = (TaskCompletionSource<int>)e.UserToken;
+            var tcs = (ReusableTaskCompletionSource<int>)e.UserToken;
             var error = e.SocketError;
             var transferred = e.BytesTransferred;
             e.RemoteEndPoint = null;
@@ -149,7 +157,6 @@ namespace MonoTorrent.Client.Connections
                 tcs.SetException(new SocketException((int) error));
             else
                 tcs.SetResult(transferred);
-
         }
 
         #endregion
@@ -157,48 +164,49 @@ namespace MonoTorrent.Client.Connections
 
         #region Async Methods
 
-        public Task ConnectAsync ()
+        public async Task ConnectAsync ()
         {
-            var tcs = new TaskCompletionSource<int>();
+            var tcs = new ReusableTaskCompletionSource<int> ();
             var args = GetSocketAsyncEventArgs (null);
             args.RemoteEndPoint = EndPoint;
             args.UserToken = tcs;
 
             if (!Socket.ConnectAsync(args))
-                return Task.FromResult(true);
-            return tcs.Task;
+                tcs.SetResult (0);
+
+            await tcs.Task;
         }
 
-        public Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
+        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
         {
             // If this has been disposed, then bail out
             if (Socket == null)
-                return FailedTask;
+                return await FailedTask;
 
-            var tcs = new TaskCompletionSource<int>();
             var args = GetSocketAsyncEventArgs (buffer);
             args.SetBuffer (offset, count);
-            args.UserToken = tcs;
+            args.UserToken = ReceiveTcs;
 
             if (!Socket.ReceiveAsync(args))
-                tcs.SetResult (args.BytesTransferred);
-            return tcs.Task;
+                ReceiveTcs.SetResult (args.BytesTransferred);
+
+            return await ReceiveTcs.Task;
         }
 
-        public Task<int> SendAsync(byte[] buffer, int offset, int count)
+        public async Task<int> SendAsync(byte[] buffer, int offset, int count)
         {
             // If this has been disposed, then bail out
             if (Socket == null)
-                return FailedTask;
+                return await FailedTask;
 
-            var tcs = new TaskCompletionSource<int>();
             var args = GetSocketAsyncEventArgs (buffer);
             args.SetBuffer (offset, count);
-            args.UserToken = tcs;
+            args.UserToken = SendTcs;
 
             if (!Socket.SendAsync(args))
-                tcs.SetResult (args.BytesTransferred);
-            return tcs.Task;
+                SendTcs.SetResult (count);
+
+            return await SendTcs.Task;
         }
 
         public void Dispose()

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
@@ -37,7 +37,7 @@ using ReusableTasks;
 
 namespace MonoTorrent.Client.Connections
 {
-    class SocketConnection : IConnection
+    class SocketConnection : IConnection2
     {
         static readonly EventHandler<SocketAsyncEventArgs> Handler = HandleOperationCompleted;
 
@@ -164,7 +164,10 @@ namespace MonoTorrent.Client.Connections
 
         #region Async Methods
 
-        public async Task ConnectAsync ()
+        async Task IConnection.ConnectAsync ()
+            => await ConnectAsync ();
+
+        public async ReusableTask ConnectAsync ()
         {
             var tcs = new ReusableTaskCompletionSource<int> ();
             var args = GetSocketAsyncEventArgs (null);
@@ -177,7 +180,10 @@ namespace MonoTorrent.Client.Connections
             await tcs.Task;
         }
 
-        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.ReceiveAsync (byte[] buffer, int offset, int count)
+            => await ReceiveAsync (buffer, offset, count);
+
+        public async ReusableTask<int> ReceiveAsync (byte[] buffer, int offset, int count)
         {
             // If this has been disposed, then bail out
             if (Socket == null)
@@ -193,7 +199,10 @@ namespace MonoTorrent.Client.Connections
             return await ReceiveTcs.Task;
         }
 
-        public async Task<int> SendAsync(byte[] buffer, int offset, int count)
+        async Task<int> IConnection.SendAsync (byte[] buffer, int offset, int count)
+            => await SendAsync (buffer, offset, count);
+
+        public async ReusableTask<int> SendAsync (byte[] buffer, int offset, int count)
         {
             // If this has been disposed, then bail out
             if (Socket == null)

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
@@ -83,7 +83,7 @@ namespace MonoTorrent.Client.Encryption
         readonly byte[] Y; // 2^X mod P
         private byte[] OtherY;
         
-        protected IConnection socket;
+        protected IConnection2 socket;
 
         // Data to be passed to initial ReceiveMessage requests
         private byte[] initialBuffer;
@@ -126,7 +126,7 @@ namespace MonoTorrent.Client.Encryption
         /// Begins the message stream encryption handshaking process
         /// </summary>
         /// <param name="socket">The socket to perform handshaking with</param>
-        public virtual async Task HandshakeAsync(IConnection socket)
+        public virtual async ReusableTask HandshakeAsync(IConnection2 socket)
         {
             this.socket = socket ?? throw new ArgumentNullException(nameof (socket));
 
@@ -152,7 +152,7 @@ namespace MonoTorrent.Client.Encryption
         /// <param name="initialBuffer">Buffer containing soome data already received from the socket</param>
         /// <param name="offset">Offset to begin reading in initialBuffer</param>
         /// <param name="count">Number of bytes to read from initialBuffer</param>
-        public virtual async Task HandshakeAsync(IConnection socket, byte[] initialBuffer, int offset, int count)
+        public virtual async ReusableTask HandshakeAsync(IConnection2 socket, byte[] initialBuffer, int offset, int count)
         {
             this.initialBuffer = initialBuffer;
             this.initialBufferOffset = offset;

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 
 using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Messages;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Encryption
 {
@@ -197,7 +198,7 @@ namespace MonoTorrent.Client.Encryption
         /// Send Y to the remote client, with a random padding that is 0 to 512 bytes long
         /// (Either "1 A->B: Diffie Hellman Ya, PadA" or "2 B->A: Diffie Hellman Yb, PadB")
         /// </summary>
-        protected async Task SendY()
+        protected async ReusableTask SendY()
         {
             byte[] toSend = new byte[96 + RandomNumber(512)];
             random.GetBytes(toSend);
@@ -210,7 +211,7 @@ namespace MonoTorrent.Client.Encryption
         /// Receive the first 768 bits of the transmission from the remote client, which is Y in the protocol
         /// (Either "1 A->B: Diffie Hellman Ya, PadA" or "2 B->A: Diffie Hellman Yb, PadB")
         /// </summary>
-        protected async Task ReceiveY()
+        protected async ReusableTask ReceiveY()
         {
             OtherY = new byte[96];
             await ReceiveMessage(OtherY, 96);
@@ -218,7 +219,7 @@ namespace MonoTorrent.Client.Encryption
             await doneReceiveY ();
         }
 
-        protected abstract Task doneReceiveY ();
+        protected abstract ReusableTask doneReceiveY ();
 
         #endregion
 
@@ -230,7 +231,7 @@ namespace MonoTorrent.Client.Encryption
         /// </summary>
         /// <param name="syncData">Buffer with the data to synchronize to</param>
         /// <param name="syncStopPoint">Maximum number of bytes (measured from the total received from the socket since connection) to read before giving up</param>
-        protected async Task Synchronize(byte[] syncData, int syncStopPoint)
+        protected async ReusableTask Synchronize(byte[] syncData, int syncStopPoint)
         {
             // The strategy here is to create a window the size of the data to synchronize and just refill that until its contents match syncData
             int filled = 0;
@@ -276,14 +277,14 @@ namespace MonoTorrent.Client.Encryption
             throw new EncryptionException("Couldn't synchronise 1");
         }
 
-        protected virtual Task doneSynchronize()
+        protected virtual ReusableTask doneSynchronize()
         {
-            return Task.CompletedTask;
+            return ReusableTask.CompletedTask;
         }
         #endregion
 
         #region I/O Functions
-        protected async Task ReceiveMessage(byte[] buffer, int length)
+        protected async ReusableTask ReceiveMessage(byte[] buffer, int length)
         {
             if (length == 0)
             {

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptorFactory.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptorFactory.cs
@@ -55,7 +55,7 @@ namespace MonoTorrent.Client.Encryption
 
         static TimeSpan Timeout => Debugger.IsAttached ? TimeSpan.FromHours (1) : TimeSpan.FromSeconds (10);
 
-        internal static async ReusableTask<EncryptorResult> CheckIncomingConnectionAsync (IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
+        internal static async ReusableTask<EncryptorResult> CheckIncomingConnectionAsync (IConnection2 connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
         {
             if (!connection.IsIncoming)
                 throw new Exception ("oops");
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Encryption
                 return await DoCheckIncomingConnectionAsync (connection, encryption, settings, sKeys);
         }
 
-        static async ReusableTask<EncryptorResult> DoCheckIncomingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
+        static async ReusableTask<EncryptorResult> DoCheckIncomingConnectionAsync(IConnection2 connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
         {
             var allowedEncryption = (settings?.AllowedEncryption ?? EncryptionTypes.All) & encryption;
             var supportsRC4Header = allowedEncryption.HasFlag (EncryptionTypes.RC4Header);
@@ -113,7 +113,7 @@ namespace MonoTorrent.Client.Encryption
             throw new EncryptionException("Invalid handshake received and no decryption works");
         }
 
-        internal static async ReusableTask<EncryptorResult> CheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake = null)
+        internal static async ReusableTask<EncryptorResult> CheckOutgoingConnectionAsync(IConnection2 connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake = null)
         {
             if (connection.IsIncoming)
                 throw new Exception ("oops");
@@ -123,7 +123,7 @@ namespace MonoTorrent.Client.Encryption
                 return await DoCheckOutgoingConnectionAsync (connection, encryption, settings, infoHash, handshake);
         }
 
-        static async ReusableTask<EncryptorResult> DoCheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake)
+        static async ReusableTask<EncryptorResult> DoCheckOutgoingConnectionAsync(IConnection2 connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake)
         {
             var allowedEncryption = settings.AllowedEncryption & encryption;
             var supportsRC4Header = allowedEncryption.HasFlag (EncryptionTypes.RC4Header);

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptorFactory.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptorFactory.cs
@@ -30,10 +30,10 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 
 using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Messages.Standard;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Encryption
 {
@@ -55,7 +55,7 @@ namespace MonoTorrent.Client.Encryption
 
         static TimeSpan Timeout => Debugger.IsAttached ? TimeSpan.FromHours (1) : TimeSpan.FromSeconds (10);
 
-        internal static async Task<EncryptorResult> CheckIncomingConnectionAsync (IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
+        internal static async ReusableTask<EncryptorResult> CheckIncomingConnectionAsync (IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
         {
             if (!connection.IsIncoming)
                 throw new Exception ("oops");
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Encryption
                 return await DoCheckIncomingConnectionAsync (connection, encryption, settings, sKeys);
         }
 
-        static async Task<EncryptorResult> DoCheckIncomingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
+        static async ReusableTask<EncryptorResult> DoCheckIncomingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash[] sKeys)
         {
             var allowedEncryption = (settings?.AllowedEncryption ?? EncryptionTypes.All) & encryption;
             var supportsRC4Header = allowedEncryption.HasFlag (EncryptionTypes.RC4Header);
@@ -113,7 +113,7 @@ namespace MonoTorrent.Client.Encryption
             throw new EncryptionException("Invalid handshake received and no decryption works");
         }
 
-        internal static async Task<EncryptorResult> CheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake = null)
+        internal static async ReusableTask<EncryptorResult> CheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake = null)
         {
             if (connection.IsIncoming)
                 throw new Exception ("oops");
@@ -123,7 +123,7 @@ namespace MonoTorrent.Client.Encryption
                 return await DoCheckOutgoingConnectionAsync (connection, encryption, settings, infoHash, handshake);
         }
 
-        static async Task<EncryptorResult> DoCheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake)
+        static async ReusableTask<EncryptorResult> DoCheckOutgoingConnectionAsync(IConnection connection, EncryptionTypes encryption, EngineSettings settings, InfoHash infoHash, HandshakeMessage handshake)
         {
             var allowedEncryption = settings.AllowedEncryption & encryption;
             var supportsRC4Header = allowedEncryption.HasFlag (EncryptionTypes.RC4Header);

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/IEncryptor.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/IEncryptor.cs
@@ -27,9 +27,8 @@
 //
 
 
-using System.Threading.Tasks;
-
 using MonoTorrent.Client.Connections;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Encryption
 {

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerAEncryption.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerAEncryption.cs
@@ -33,6 +33,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using MonoTorrent.Client.Messages;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Encryption
 {
@@ -56,7 +57,7 @@ namespace MonoTorrent.Client.Encryption
             SKEY = InfoHash;
         }
 
-        protected override async Task doneReceiveY()
+        protected override async ReusableTask doneReceiveY()
         {
             CreateCryptors("keyA", "keyB");
 
@@ -98,7 +99,7 @@ namespace MonoTorrent.Client.Encryption
             await Synchronize(VerificationConstant, 616); // 4 B->A: ENCRYPT(VC)
         }
 
-        protected override async Task doneSynchronize()
+        protected override async ReusableTask doneSynchronize()
         {
             await base.doneSynchronize(); // 4 B->A: ENCRYPT(VC, ...
 

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerBEncryption.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerBEncryption.cs
@@ -33,6 +33,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using MonoTorrent.Client.Messages;
+using ReusableTasks;
 
 namespace MonoTorrent.Client.Encryption
 {
@@ -52,13 +53,13 @@ namespace MonoTorrent.Client.Encryption
             PossibleSKEYs = possibleSKEYs;
         }
 
-        protected override async Task doneReceiveY()
+        protected override async ReusableTask doneReceiveY()
         {
             byte[] req1 = Hash(Encoding.ASCII.GetBytes("req1"), S);
             await Synchronize(req1, 628); // 3 A->B: HASH('req1', S)
         }
 
-        protected override async Task doneSynchronize()
+        protected override async ReusableTask doneSynchronize()
         {
             await base.doneSynchronize();
 
@@ -68,7 +69,7 @@ namespace MonoTorrent.Client.Encryption
             await gotVerification(verifyBytes);
         }
 
-        private async Task gotVerification(byte[] verifyBytes)
+        private async ReusableTask gotVerification(byte[] verifyBytes)
         {
             byte[] torrentHash = new byte[20];
 

--- a/src/MonoTorrent/MonoTorrent.Client/EventArgs/NewConnectionEventArgs.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/EventArgs/NewConnectionEventArgs.cs
@@ -1,23 +1,42 @@
+//
+// NewConnectionEventArgs.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
 using System;
-using System.Collections.Generic;
-using System.Text;
+
 using MonoTorrent.Client.Connections;
 
 namespace MonoTorrent.Client
 {
     public class NewConnectionEventArgs : TorrentEventArgs
     {
-        private IConnection connection;
-        private Peer peer;
-        public IConnection Connection
-        {
-            get { return connection; }
-        }
-
-        public Peer Peer
-        {
-            get { return peer; }
-        }
+        public IConnection Connection { get; }
+        public Peer Peer { get; }
 
         public NewConnectionEventArgs(Peer peer, IConnection connection, TorrentManager manager)
             : base(manager)
@@ -25,8 +44,8 @@ namespace MonoTorrent.Client
             if (!connection.IsIncoming && manager == null)
                 throw new InvalidOperationException("An outgoing connection must specify the torrent manager it belongs to");
 
-            this.connection = connection;
-            this.peer = peer;
+            Connection = connection;
+            Peer = peer;
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -115,7 +115,7 @@ namespace MonoTorrent.Client
         internal async void ConnectToPeer(TorrentManager manager, Peer peer)
         {
             // Connect to the peer.
-            IConnection connection = ConnectionFactory.Create(peer.ConnectionUri);
+            IConnection2 connection = ConnectionConverter.Convert (ConnectionFactory.Create(peer.ConnectionUri));
             if (connection == null)
                 return;
 
@@ -227,7 +227,7 @@ namespace MonoTorrent.Client
             }
         }
 
-        async void ReceiveMessagesAsync (IConnection connection, IEncryption decryptor, RateLimiterGroup downloadLimiter, ConnectionMonitor monitor, TorrentManager torrentManager, PeerId id)
+        async void ReceiveMessagesAsync (IConnection2 connection, IEncryption decryptor, RateLimiterGroup downloadLimiter, ConnectionMonitor monitor, TorrentManager torrentManager, PeerId id)
         {
             try {
                 while (true)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
@@ -94,9 +94,10 @@ namespace MonoTorrent.Client
                 for (int i = 0; i < Engine.Torrents.Count; i++)
                     skeys.Add(Engine.Torrents[i].InfoHash);
 
-                var result = await EncryptorFactory.CheckIncomingConnectionAsync(e.Connection, e.Peer.AllowedEncryption, Engine.Settings, skeys.ToArray());
-                if (!await HandleHandshake(e.Peer, e.Connection, result.Handshake, result.Decryptor, result.Encryptor))
-                    e.Connection.Dispose();
+                var connection = ConnectionConverter.Convert (e.Connection);
+                var result = await EncryptorFactory.CheckIncomingConnectionAsync(connection, e.Peer.AllowedEncryption, Engine.Settings, skeys.ToArray());
+                if (!await HandleHandshake(e.Peer, connection, result.Handshake, result.Decryptor, result.Encryptor))
+                    connection.Dispose();
             }
             catch
             {

--- a/src/MonoTorrent/MonoTorrent.Client/NetworkIO.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/NetworkIO.cs
@@ -42,14 +42,14 @@ namespace MonoTorrent.Client
 
         public struct QueuedIO
         {
-            public IConnection connection;
+            public IConnection2 connection;
             public byte [] buffer;
             public int offset;
             public int count;
             public IRateLimiter rateLimiter;
             public ReusableTaskCompletionSource<int> tcs;
 
-            public QueuedIO (IConnection connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, ReusableTaskCompletionSource<int> tcs)
+            public QueuedIO (IConnection2 connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, ReusableTaskCompletionSource<int> tcs)
             {
                 this.connection = connection;
                 this.buffer = buffer;
@@ -109,17 +109,17 @@ namespace MonoTorrent.Client
             }
         }
 
-        public static async ReusableTask ConnectAsync (IConnection connection)
+        public static async ReusableTask ConnectAsync (IConnection2 connection)
         {
             await IOLoop;
 
             await connection.ConnectAsync ();
         }
 
-        public static ReusableTask ReceiveAsync(IConnection connection, byte [] buffer, int offset, int count)
+        public static ReusableTask ReceiveAsync(IConnection2 connection, byte [] buffer, int offset, int count)
             => ReceiveAsync (connection, buffer, offset, count, null, null, null);
 
-        public static async ReusableTask ReceiveAsync(IConnection connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, SpeedMonitor peerMonitor, SpeedMonitor managerMonitor)
+        public static async ReusableTask ReceiveAsync(IConnection2 connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, SpeedMonitor peerMonitor, SpeedMonitor managerMonitor)
         {
             await IOLoop;
 
@@ -148,10 +148,10 @@ namespace MonoTorrent.Client
             } 
         }
 
-        public static ReusableTask SendAsync (IConnection connection, byte [] buffer, int offset, int count)
+        public static ReusableTask SendAsync (IConnection2 connection, byte [] buffer, int offset, int count)
             => SendAsync (connection, buffer, offset, count, null, null, null);
 
-        public static async ReusableTask SendAsync (IConnection connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, SpeedMonitor peerMonitor, SpeedMonitor managerMonitor)
+        public static async ReusableTask SendAsync (IConnection2 connection, byte [] buffer, int offset, int count, IRateLimiter rateLimiter, SpeedMonitor peerMonitor, SpeedMonitor managerMonitor)
         {
             await IOLoop;
 

--- a/src/MonoTorrent/MonoTorrent.Client/PeerIO.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/PeerIO.cs
@@ -29,13 +29,13 @@
 
 using System;
 using System.Net;
-using System.Threading.Tasks;
 
 using MonoTorrent.Client.Connections;
 using MonoTorrent.Client.Encryption;
 using MonoTorrent.Client.Messages;
 using MonoTorrent.Client.Messages.Standard;
 using MonoTorrent.Client.RateLimiters;
+using ReusableTasks;
 
 namespace MonoTorrent.Client
 {
@@ -43,7 +43,7 @@ namespace MonoTorrent.Client
     {
         const int MaxMessageLength = Piece.BlockSize * 4;
 
-        public static async Task<HandshakeMessage> ReceiveHandshakeAsync (IConnection connection, IEncryption decryptor)
+        public static async ReusableTask<HandshakeMessage> ReceiveHandshakeAsync (IConnection connection, IEncryption decryptor)
         {
             var buffer = ClientEngine.BufferManager.GetBuffer (HandshakeMessage.HandshakeLength);
             try {
@@ -59,10 +59,10 @@ namespace MonoTorrent.Client
             }
         }
 
-        public static Task<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor)
+        public static ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor)
             => ReceiveMessageAsync (connection, decryptor, null, null, null);
 
-        public static async Task<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor monitor, TorrentManager manager)
+        public static async ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor monitor, TorrentManager manager)
         {
             byte[] messageLengthBuffer = null;
             byte[] messageBuffer = null;
@@ -111,10 +111,10 @@ namespace MonoTorrent.Client
             }
         }
 
-        public static Task SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message)
+        public static ReusableTask SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message)
             => SendMessageAsync (connection, encryptor, message, null, null, null);
 
-        public static async Task SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor)
+        public static async ReusableTask SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor)
         {
             int count = message.ByteLength;
             var buffer = ClientEngine.BufferManager.GetBuffer (count);

--- a/src/MonoTorrent/MonoTorrent.Client/PeerIO.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/PeerIO.cs
@@ -43,7 +43,7 @@ namespace MonoTorrent.Client
     {
         const int MaxMessageLength = Piece.BlockSize * 4;
 
-        public static async ReusableTask<HandshakeMessage> ReceiveHandshakeAsync (IConnection connection, IEncryption decryptor)
+        public static async ReusableTask<HandshakeMessage> ReceiveHandshakeAsync (IConnection2 connection, IEncryption decryptor)
         {
             var buffer = ClientEngine.BufferManager.GetBuffer (HandshakeMessage.HandshakeLength);
             try {
@@ -59,10 +59,10 @@ namespace MonoTorrent.Client
             }
         }
 
-        public static ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor)
+        public static ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection2 connection, IEncryption decryptor)
             => ReceiveMessageAsync (connection, decryptor, null, null, null);
 
-        public static async ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor monitor, TorrentManager manager)
+        public static async ReusableTask<PeerMessage> ReceiveMessageAsync (IConnection2 connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor monitor, TorrentManager manager)
         {
             byte[] messageLengthBuffer = null;
             byte[] messageBuffer = null;
@@ -111,10 +111,10 @@ namespace MonoTorrent.Client
             }
         }
 
-        public static ReusableTask SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message)
+        public static ReusableTask SendMessageAsync (IConnection2 connection, IEncryption encryptor, PeerMessage message)
             => SendMessageAsync (connection, encryptor, message, null, null, null);
 
-        public static async ReusableTask SendMessageAsync (IConnection connection, IEncryption encryptor, PeerMessage message, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor)
+        public static async ReusableTask SendMessageAsync (IConnection2 connection, IEncryption encryptor, PeerMessage message, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor)
         {
             int count = message.ByteLength;
             var buffer = ClientEngine.BufferManager.GetBuffer (count);

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -96,6 +96,7 @@ Notable features include:
 
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
+    <PackageReference Include="ReusableTasks" Version="0.99.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonoTorrent/System.Runtime.CompilerServices/AsyncVoidMethodBuilder.cs
+++ b/src/MonoTorrent/System.Runtime.CompilerServices/AsyncVoidMethodBuilder.cs
@@ -1,0 +1,72 @@
+﻿//
+// AsyncVoidMethodBuilder.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+#pragma warning disable CS0436 // Type conflicts with imported type
+
+namespace System.Runtime.CompilerServices
+{
+    struct AsyncVoidMethodBuilder
+    {
+        public static AsyncVoidMethodBuilder Create () => new AsyncVoidMethodBuilder ();
+
+        public void SetException (Exception e)
+        {
+        }
+
+        public void SetResult ()
+        {
+        }
+
+        public void SetStateMachine (IAsyncStateMachine stateMachine)
+        {
+        }
+
+        public void Start<TStateMachine> (ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine
+        {
+            stateMachine.MoveNext ();
+        }
+
+        public void AwaitOnCompleted<TAwaiter, TStateMachine> (ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            StateMachineCache<TStateMachine>.GetOrCreate ()
+                .AwaitOnCompleted (ref awaiter, ref stateMachine);
+        }
+
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine> (ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            StateMachineCache<TStateMachine>.GetOrCreate ()
+                .AwaitUnsafeOnCompleted (ref awaiter, ref stateMachine);
+        }
+    }
+}


### PR DESCRIPTION
Setup:
* Debug build
* Only peers on my local network are used, no internet based peers.
* Two 2GB torrents fully downloaded

Memory allocations before changes:
![Memory_Unoptimised](https://user-images.githubusercontent.com/264396/67574822-1a691d80-f733-11e9-87a3-6175f8306205.png)

Memory allocations after changes:
![Memory_Optimised](https://user-images.githubusercontent.com/264396/67574845-2654df80-f733-11e9-852a-57330d5255bd.png)

