### PR TITLE
[core] Do not cache old buffers longer than needed

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/SocketConnection.cs
@@ -150,9 +150,13 @@ namespace MonoTorrent.Client.Connections
 
             // If the 'SocketAsyncEventArgs' was used to connect, or if it was using a buffer
             // *not* managed by our BufferManager, then we should put it back in the 'other' cache.
-            if (e.Buffer == null || !ClientEngine.BufferManager.OwnsBuffer (e.Buffer))
-                lock (bufferCache)
-                    otherCache.Enqueue (e);
+            if (e.Buffer == null || !ClientEngine.BufferManager.OwnsBuffer(e.Buffer))  {
+                lock (bufferCache) {
+                    if (e.Buffer != null)
+                        e.SetBuffer(null, 0, 0);
+                    otherCache.Enqueue(e);
+                }
+            }
 
             if (error != SocketError.Success)
                 tcs.SetException(new SocketException((int) error));


### PR DESCRIPTION
If we are using a SocketAsyncEventArgs to wrap a buffer which
does not come from the pool, ensure we null out the buffer when
we finish with that invocation.

Allows the buffer to be GCed eventually.