### PR TITLE
[tests] Always set an IP and a port for Peer Uris

### DIFF
--- a/src/MonoTorrent.Tests/Client/HttpTrackerTests.cs
+++ b/src/MonoTorrent.Tests/Client/HttpTrackerTests.cs
@@ -86,6 +86,7 @@ namespace MonoTorrent.Client.Tracker
 
             infoHash = new InfoHash (infoHashBytes.Concat (infoHashBytes).ToArray ());
             announceParams = new AnnounceParameters()
+                .WithPort (5555)
                 .WithPeerId (peerId)
                 .WithInfoHash (infoHash);
 

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -67,7 +67,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
                 ProcessingQueue = true
             };
         }
@@ -148,7 +148,7 @@ namespace MonoTorrent.Client.Modes
             };
 
             TrackerManager.AddTracker ("http://test.tracker");
-            TrackerManager.RaiseAnnounceComplete (TrackerManager.CurrentTracker, true, new [] { new Peer ("One", new Uri ("ipv4://1.1.1.1")), new Peer ("Two", new Uri ("ipv4://2.2.2.2")) });
+            TrackerManager.RaiseAnnounceComplete (TrackerManager.CurrentTracker, true, new [] { new Peer ("One", new Uri ("ipv4://1.1.1.1:1111")), new Peer ("Two", new Uri ("ipv4://2.2.2.2:2222")) });
 
             var addedArgs = await peersTask.Task.WithTimeout ();
             Assert.AreEqual (2, addedArgs.NewPeers, "#1");

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (true)) {
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (true)) {
                 ProcessingQueue = true,
                 IsChoking = false,
                 AmInterested = true,

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
@@ -63,7 +63,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
                 ProcessingQueue = true
             };
         }

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
@@ -64,7 +64,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:5555"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false)) {
                 ProcessingQueue = true
             };
         }

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -49,7 +49,7 @@ namespace MonoTorrent.Client
         /// <returns></returns>
         internal static PeerId CreateNull (int bitfieldLength)
         {
-            return new PeerId (new Peer ("null", new Uri ("ipv4://hardcodedvalue"))) {
+            return new PeerId (new Peer ("null", new Uri ("ipv4://hardcodedvalue:12345"))) {
                 IsChoking = true,
                 AmChoking = true,
                 BitField = new BitField (bitfieldLength),


### PR DESCRIPTION
This is in advance of adding sanity checks to the peer parsing
code to ensure we never accept peers which are missing a port.