### PR TITLE
[core] Reduce allocations from PieceManager

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Messages/MutableRequestMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/MutableRequestMessage.cs
@@ -1,0 +1,52 @@
+﻿//
+// MutableRequestMessage.cs
+//
+// Authors:
+//   Alan McGovern <alan.mcgovern@gmail.com>
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace MonoTorrent.Client.Messages.Standard
+{
+    class MutableRequestMessage : RequestMessage
+    {
+        public new int PieceIndex
+        {
+            get => base.PieceIndex;
+            set => base.PieceIndex = value;
+        }
+
+        public new int RequestLength
+        {
+            get => base.RequestLength;
+            set => base.RequestLength = value;
+        }
+
+        public new int StartOffset
+        {
+            get => base.StartOffset;
+            set => base.StartOffset = value;
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/RequestBundle.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/RequestBundle.cs
@@ -1,0 +1,71 @@
+﻿//
+// RequestBundle.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Collections.Generic;
+
+using MonoTorrent.Client.Messages.Standard;
+using MonoTorrent.Client.PiecePicking;
+
+namespace MonoTorrent.Client.Messages
+{
+    class RequestBundle : PeerMessage
+    {
+        MutableRequestMessage Message { get; }
+        IList<PieceRequest> Requests { get; }
+
+        internal RequestBundle(IList<PieceRequest> requests)
+        {
+            Message = new MutableRequestMessage();
+            Requests = requests;
+        }
+
+        public override int ByteLength => Message.ByteLength * Requests.Count;
+
+        public override void Decode(byte[] buffer, int offset, int length)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override int Encode(byte[] buffer, int offset)
+        {
+            int written = offset;
+
+            for (int i = 0; i < Requests.Count; i++)
+            {
+                Message.PieceIndex = Requests[i].PieceIndex;
+                Message.RequestLength = Requests[i].RequestLength;
+                Message.StartOffset = Requests[i].StartOffset;
+                written += Message.Encode(buffer, written);
+            }
+
+            return CheckWritten(written - offset);
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/RequestMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/RequestMessage.cs
@@ -41,9 +41,9 @@ namespace MonoTorrent.Client.Messages.Standard
         #region Public Properties
 
         public override int ByteLength => messageLength + 4;
-        public int PieceIndex { get; private set; }
-        public int RequestLength { get; private set; }
-        public int StartOffset { get; private set; }
+        public int PieceIndex { get; protected set; }
+        public int RequestLength { get; protected set; }
+        public int StartOffset { get; protected set; }
 
         #endregion
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using MonoTorrent.Client.Connections;
+using MonoTorrent.Client.Messages;
 using MonoTorrent.Client.Messages.Standard;
 using MonoTorrent.Client.PiecePicking;
 
@@ -134,10 +135,9 @@ namespace MonoTorrent.Client
                 while (id.AmRequestingPiecesCount < maxRequests)
                 {
                     var otherPeers = Manager.Peers.ConnectedPeers ?? new List<PeerId> ();
-                    var request = Picker.PickPiece(id, id.BitField, new List<IPieceRequester> (otherPeers), count);
+                    var request = Picker.PickPiece(id, id.BitField, otherPeers, count);
                     if (request != null && request.Count > 0)
-                        for (int i = 0; i < request.Count; i ++)
-                            id.Enqueue(new RequestMessage (request[i].PieceIndex, request[i].StartOffset, request[i].RequestLength));
+                        id.Enqueue(new RequestBundle(request));
                     else
                         break;
                 }


### PR DESCRIPTION
Don't allocate a new list every time we pick a piece. We
can pass in the existing list exactly as-is.

Also, don't create one RequestMessage for every PieceRequest.
We can optimise the common case of having dozens of requests
by creating another type like MessageBundle, which can write
multiple requests into one buffer.