### PR TITLE
[core] Cancel all pending requests when the piece has been received

### DIFF
--- a/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
@@ -88,6 +88,29 @@ namespace MonoTorrent.Client.PiecePicking
         }
 
         [Test]
+        public void CancelAllPendingWhenPieceReceived ()
+        {
+            id.BitField[0] = other.BitField [0] = true;
+            picker.Initialise(bitfield, torrentData, new List<Piece>());
+
+            var otherRequest = picker.PickPiece (other, other.BitField, new List<PeerId> ());
+
+            PieceRequest message;
+            Piece piece;
+            while ((message = picker.PickPiece(id, id.BitField, new List<PeerId>())) != null) {
+                Assert.IsTrue(picker.ValidatePiece(id, message.PieceIndex, message.StartOffset, message.RequestLength, out piece));
+                if (piece.AllBlocksReceived)
+                    break;
+            }
+
+            Assert.IsFalse (picker.ValidatePiece (other, otherRequest.PieceIndex, otherRequest.StartOffset, otherRequest.RequestLength, out piece), "#1");
+            Assert.IsNull (piece, "#2");
+
+            message = picker.PickPiece (other, other.BitField, new List<PeerId> ());
+            Assert.AreEqual (0, message.PieceIndex, "#3");
+        }
+
+        [Test]
         public void CancelTest()
         {
             foreach (Piece p in pieces)

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGamePicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGamePicker.cs
@@ -251,8 +251,10 @@ namespace MonoTorrent.Client.PiecePicking
             // Once a piece is completely received, remove it from our list.
             // If a piece *fails* the hashcheck, we need to add it back into the list so
             // we download it again.
-            if (piece.AllBlocksReceived)
+            if (piece.AllBlocksReceived) {
                 pieces.Remove(piece);
+                CancelWhere (r => r.Block.PieceIndex == pieceIndex, false);
+            }
 
             requests.Remove(r);
             peer.AmRequestingPiecesCount--;


### PR DESCRIPTION
In endgame mode ensure that *all* pending requests for a given piece
are cancelled if/when every block for a piece has been received once.

This ensure that when the piece is hash checked, we will be able to
fully redownload all pieces if the hash check fails.