### PR TITLE
[core] Move TorrentCreator to read and hash in parallel

### DIFF
--- a/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
@@ -16,14 +16,7 @@ namespace MonoTorrent.Common
     public class TestTorrentCreator : TorrentCreator
     {
         protected override IPieceWriter CreateReader()
-        {
-            TestWriter writer = new TestWriter();
-            writer.DontWrite = true;
-            return writer;
-        }
-
-        public BEncodedDictionary Create (string name, List<TorrentFile> files)
-            => Create (name, files, CancellationToken.None);
+            => new TestWriter { DontWrite = true };
     }
 
     [TestFixture]
@@ -129,6 +122,7 @@ namespace MonoTorrent.Common
             Assert.AreEqual(1, torrent.Files.Length, "#1");
             Assert.AreEqual(f, torrent.Files[0], "#2");
         }
+
         [Test]
         public void CreateSingleFromFolder()
         {

--- a/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
@@ -189,6 +189,10 @@ namespace MonoTorrent.Client
         {
             Queue (new QueuedTask { Action = continuation });
         }
+
+        public static ThreadPoolAwaitable SwitchToThreadpool ()
+            => new ThreadPoolAwaitable ();
+
         #endregion
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/ThreadpoolAwaitable.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ThreadpoolAwaitable.cs
@@ -1,0 +1,59 @@
+﻿//
+// ThreadPoolAwaitable.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace MonoTorrent.Client
+{
+    struct ThreadPoolAwaitable : INotifyCompletion
+    {
+        static readonly WaitCallback Callback = (state) => ((Action) state).Invoke ();
+
+        [EditorBrowsable (EditorBrowsableState.Never)]
+        public ThreadPoolAwaitable GetAwaiter () => this;
+
+        [EditorBrowsable (EditorBrowsableState.Never)]
+        public bool IsCompleted => Thread.CurrentThread.IsThreadPoolThread;
+
+        [EditorBrowsable (EditorBrowsableState.Never)]
+        public void GetResult()
+        {
+
+        }
+
+        [EditorBrowsable (EditorBrowsableState.Never)]
+        public void OnCompleted(Action continuation)
+        {
+            ThreadPool.UnsafeQueueUserWorkItem (Callback, continuation);
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -92,7 +92,7 @@ Notable features include:
 
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
-    <PackageReference Include="ReusableTasks" Version="1.0.1" />
+    <PackageReference Include="ReusableTasks" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonoTorrent/MonoTorrent/EditableTorrent.cs
+++ b/src/MonoTorrent/MonoTorrent/EditableTorrent.cs
@@ -42,7 +42,7 @@ namespace MonoTorrent
         static readonly BEncodedString CreatedByKey = "created by";
         static readonly BEncodedString EncodingKey = "encoding";
         static readonly BEncodedString InfoKey = "info";
-        static readonly BEncodedString PieceLengthKey = "piece length";
+        private protected static readonly BEncodedString PieceLengthKey = "piece length";
         static readonly BEncodedString PrivateKey = "private";
         static readonly BEncodedString PublisherKey = "publisher";
         static readonly BEncodedString PublisherUrlKey = "publisher-url";


### PR DESCRIPTION
This is a v1 refactor to test the idea of putting disk IO
in one thread and SHA1 hashing in a second thread. Unsurprisingly
this scales nearly linearly with the number of cores on the
machine, for at least my two machines.