### PR TITLE
[core] Move TorrentCreator to read and hash in parallel

### DIFF
--- a/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
@@ -16,14 +16,7 @@ namespace MonoTorrent.Common
     public class TestTorrentCreator : TorrentCreator
     {
         protected override IPieceWriter CreateReader()
-        {
-            TestWriter writer = new TestWriter();
-            writer.DontWrite = true;
-            return writer;
-        }
-
-        public BEncodedDictionary Create (string name, List<TorrentFile> files)
-            => Create (name, files, CancellationToken.None);
+            => new TestWriter { DontWrite = true };
     }
 
     [TestFixture]
@@ -132,6 +125,7 @@ namespace MonoTorrent.Common
             Assert.AreEqual(1, torrent.Files.Length, "#1");
             Assert.AreEqual(f, torrent.Files[0], "#2");
         }
+
         [Test]
         public void CreateSingleFromFolder()
         {

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -91,8 +91,8 @@ Notable features include:
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
-    <PackageReference Include="ReusableTasks" Version="1.0.1" />
+    <PackageReference Include="GitInfo" Version="2.0.21" PrivateAssets="all" />
+    <PackageReference Include="ReusableTasks" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MonoTorrent/MonoTorrent/TorrentCreatorWorker.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentCreatorWorker.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+
+using MonoTorrent.Client;
+using MonoTorrent.Client.PieceWriters;
+
+using ReusableTasks;
+
+namespace MonoTorrent
+{
+    class TorrentCreatorWorker
+    {
+        public TimeSpan ReadAllData_DequeueBufferTime;
+        public TimeSpan ReadAllData_EnqueueFilledBufferTime;
+        public TimeSpan ReadAllData_ReadTime;
+
+        public TimeSpan Hashing_DequeueFilledTime;
+        public TimeSpan Hashing_HashingTime;
+        public TimeSpan Hashing_EnqueueEmptyTime;
+
+        List<TorrentFile> Files { get; }
+        long PieceStart { get; }
+        long PieceCount { get; }
+        long PieceLength { get; }
+        IPieceWriter Writer { get; }
+
+        public TorrentCreatorWorker (long pieceStart, long pieceCount, long pieceLength, List<TorrentFile> files, IPieceWriter writer)
+        {
+            PieceStart = pieceStart;
+            PieceCount = pieceCount;
+            PieceLength = pieceLength;
+            Files = files;
+            Writer = writer;
+        }
+
+        public async ReusableTask CalculateHashes (byte[] torrentHashes, CancellationToken token)
+        {
+            await MainLoop.SwitchToThreadpool ();
+
+            // We should be hashing Block N, have Block N + 1 in memory and be reading Block N + 2.
+            var emptyBuffers = new AsyncProducerConsumerQueue<byte[]> (8);
+            var filledBuffers = new AsyncProducerConsumerQueue<(byte[], int, int)> (8);
+
+            for (int i = 0; i < emptyBuffers.Capacity; i ++)
+                await emptyBuffers.EnqueueAsync (new byte[TorrentCreator.BlockSize]);
+
+            using var shaHasher = HashAlgoFactory.Create<SHA1> ();
+
+            using var emptyBuffersDisposal = token.Register (emptyBuffers.CompleteAdding);
+            using var filledBuffersDisposal = token.Register (filledBuffers.CompleteAdding);
+
+            var readTask = ReadAllData (emptyBuffers, filledBuffers).AsTask ();
+            _ = readTask.ContinueWith (t => {
+                if (t.IsFaulted) {
+                    emptyBuffers.CompleteAdding ();
+                    filledBuffers.CompleteAdding ();
+                }
+            }, System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted | System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+
+            var timer = ValueStopwatch.StartNew ();
+            shaHasher.Initialize ();
+            while (true) {
+                byte[] buffer;
+                int read;
+                int pieceIndex;
+
+                try {
+                    timer.Restart ();
+                    (buffer, read, pieceIndex) = await filledBuffers.DequeueAsync ();
+                    Hashing_DequeueFilledTime += timer.Elapsed;
+                } catch (InvalidOperationException) {
+                    // We got this probably because we're all done. Check for cancellation first, and
+                    // if we haven't been cancelled let's gracefully bail out!
+                    token.ThrowIfCancellationRequested ();
+                    break;
+                }
+
+                // The piece has been fully read.
+                if (buffer == null) {
+                    shaHasher.TransformFinalBlock (Array.Empty<byte> (), 0, 0);
+                    Array.Copy (shaHasher.Hash, 0, torrentHashes, pieceIndex * 20, shaHasher.Hash.Length);
+                    shaHasher.Initialize ();
+                } else {
+                    timer.Restart ();
+                    shaHasher?.TransformBlock (buffer, 0, read, buffer, 0);
+                    Hashing_HashingTime += timer.Elapsed;
+
+                    timer.Restart ();
+                    await emptyBuffers.EnqueueAsync (buffer);
+                    Hashing_EnqueueEmptyTime += timer.Elapsed;
+                }
+            }
+
+            await readTask;
+        }
+
+        async ReusableTask ReadAllData (AsyncProducerConsumerQueue<byte[]> emptyBuffers, AsyncProducerConsumerQueue<(byte[], int, int)> filledBuffers)
+        {
+            await MainLoop.SwitchToThreadpool ();
+
+            var timer = ValueStopwatch.StartNew ();
+
+            using var stream = new FileStream (Files[0].FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 128 * 1024, FileOptions.SequentialScan);
+
+            stream.Seek (PieceStart * PieceLength, SeekOrigin.Begin);
+            var totalLength = Files.Sum (t => t.Length);
+            for (int i = 0; i < PieceCount; i ++) {
+                long torrentOffset = (PieceStart + i) * PieceLength;
+                long availableToRead = (int) Math.Min (PieceLength, totalLength - torrentOffset);
+                int read = 0;
+                while (availableToRead > 0) {
+                    timer.Restart ();
+                    var buffer = await emptyBuffers.DequeueAsync ().ConfigureAwait (false);
+                    ReadAllData_DequeueBufferTime += timer.Elapsed;
+
+                    timer.Restart ();
+                    var count = (int) Math.Min (buffer.Length, availableToRead);
+                    if (stream.Position != torrentOffset + read)
+                        stream.Seek (torrentOffset + read, SeekOrigin.Begin);
+                    if (stream.Read (buffer, 0 , count) != count)
+                        throw new IOException ("Could not read requested data");
+                    availableToRead -= count;
+                    read += count;
+                    ReadAllData_ReadTime += timer.Elapsed;
+
+                    timer.Restart ();
+                    await filledBuffers.EnqueueAsync ((buffer, count, (int)(torrentOffset / PieceLength))).ConfigureAwait (false);
+                    ReadAllData_EnqueueFilledBufferTime += timer.Elapsed;
+                }
+
+                timer.Restart ();
+                await filledBuffers.EnqueueAsync ((null, 0, (int)(torrentOffset / PieceLength))).ConfigureAwait (false);
+                ReadAllData_EnqueueFilledBufferTime += timer.Elapsed;
+            }
+            filledBuffers.CompleteAdding ();
+        }
+
+        bool Read (byte[] buffer, long torrentOffset, int count)
+        {
+            int i;
+            int totalRead = 0;
+            var files = Files;
+
+            for (i = 0; i < files.Count; i++)
+            {
+                if (torrentOffset < files[i].Length)
+                    break;
+
+                torrentOffset -= files[i].Length;
+            }
+
+            while (totalRead < count)
+            {
+                int fileToRead = (int)Math.Min(files[i].Length - torrentOffset, count - totalRead);
+
+                lock (Writer)
+                    if (fileToRead != Writer.Read(files[i], torrentOffset, buffer, totalRead, fileToRead)) {
+                        return false;
+                    }
+
+                torrentOffset += fileToRead;
+                totalRead += fileToRead;
+                if (torrentOffset >= files[i].Length)
+                {
+                    torrentOffset = 0;
+                    i++;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/SampleClient/main.cs
+++ b/src/SampleClient/main.cs
@@ -26,6 +26,23 @@ namespace SampleClient
 
         static void Main(string[] args)
         {
+            while (true) {
+                var creator = new TorrentCreator ();
+                Console.WriteLine ("Enter parallel factor: ");
+                creator.ParallelFactor = int.Parse (Console.ReadLine ());
+                var bytes = creator.Create (new TorrentFileSource ("large.mov")).Encode ();
+                Console.WriteLine ("Total:             {0}", creator.CreationTime);
+                Console.WriteLine ();
+                Console.WriteLine ("ReadAll - Dequeue: {0}", creator.ReadAllData_DequeueBufferTime);
+                Console.WriteLine ("ReadAll - Read:    {0}", creator.ReadAllData_ReadTime);
+                Console.WriteLine ("ReadAll - Enqueue: {0}", creator.ReadAllData_EnqueueFilledBufferTime);
+                Console.WriteLine ();
+                Console.WriteLine ("Hashing - Dequeue: {0}", creator.Hashing_DequeueFilledTime);
+                Console.WriteLine ("Hashing - Hashing: {0}", creator.Hashing_HashingTime);
+                Console.WriteLine ("Hashing - Enqueue: {0}", creator.Hashing_EnqueueEmptyTime);
+                File.WriteAllBytes ("bigfile.torrent", bytes);
+            }
+
             /* Generate the paths to the folder we will save .torrent files to and where we download files to */
             basePath = Environment.CurrentDirectory;						// This is the directory we are currently in
             torrentsPath = Path.Combine(basePath, "Torrents");				// This is the directory we will save .torrents to


### PR DESCRIPTION
This is a v1 refactor to test the idea of putting disk IO in one thread and SHA1 hashing in a second thread when hashing torrents.

The original implementation parallelised on each 16kB chunks as I was investigating what it would take to create merkle trees as per bittorrent v2 spec[0]. However, normal bittorrent hashing can only parallelise on entire pieces, which will require a little bit more work in order to get the same scaling benefits as the merkle tree approach received.

[0] tl;dr i don't see any benefit in implementing this as only one other client has attempted to do so, and the spec is so poor it doesn't provide a usable description of the new messages it has introduced. The only way to implement it is to look at the only pre-existing implementation and replicate the approach/layout they used for the new messages, or guess and probably be incompatible.