### PR TITLE
[core] Do not ignore FileNotFoundException when discovering local peers.

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -166,6 +166,10 @@ namespace MonoTorrent.Client
             Check.Listener(listener);
             Check.Writer(writer);
 
+            // This is just a sanity check to make sure the ReusableTasks.dll assembly is
+            // loadable.
+            GC.KeepAlive (ReusableTasks.ReusableTask.CompletedTask);
+
             PeerId = GeneratePeerId();
             Listener = listener ?? throw new ArgumentNullException (nameof (listener));
             Settings = settings ?? throw new ArgumentNullException (nameof (settings));

--- a/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
@@ -153,8 +153,8 @@ namespace MonoTorrent.Client
                     var uri = new Uri("ipv4://" + result.RemoteEndPoint.Address + ':' + portcheck);
 
                     PeerFound?.InvokeAsync (this, new LocalPeerFoundEventArgs (infoHash, uri));
-                } catch (FileNotFoundException ex) {
-                    throw ex;
+                } catch (FileNotFoundException) {
+                    throw;
                 } catch {
 
                 }

--- a/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -152,6 +153,8 @@ namespace MonoTorrent.Client
                     var uri = new Uri("ipv4://" + result.RemoteEndPoint.Address + ':' + portcheck);
 
                     PeerFound?.InvokeAsync (this, new LocalPeerFoundEventArgs (infoHash, uri));
+                } catch (FileNotFoundException ex) {
+                    throw ex;
                 } catch {
 
                 }


### PR DESCRIPTION
The previous catch-all exception handling would enter an infinite loop when
for some reason ReusableTasks.dll was not properly deployed.