### PR TITLE
[tests] Ensure the TestWriter doesn't allow accidental overreads

### DIFF
--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -59,6 +59,8 @@ namespace MonoTorrent.Client
             if (!Paths.Contains(file.FullPath))
                 Paths.Add(file.FullPath);
 
+            if ((offset + count) > file.Length)
+                throw new ArgumentOutOfRangeException("Tried to read past the end of the file");
             if (!DontWrite)
                 for (int i = 0; i < count; i++)
                     buffer[bufferOffset + i] = (byte)(bufferOffset + i);


### PR DESCRIPTION
This is an additional safety check to ensure logic internal to
the library never over-reads.