### PR TITLE
Create torrents in parallel

### DIFF
--- a/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
@@ -21,9 +21,6 @@ namespace MonoTorrent.Common
             writer.DontWrite = true;
             return writer;
         }
-
-        public BEncodedDictionary Create (string name, List<TorrentFile> files)
-            => Create (name, files, CancellationToken.None);
     }
 
     [TestFixture]
@@ -90,16 +87,16 @@ namespace MonoTorrent.Common
         public void AutoSelectPieceLength ()
         {
             var torrentCreator = new TestTorrentCreator ();
-            Assert.DoesNotThrow (() => torrentCreator.Create ("name", files, CancellationToken.None));
+            Assert.DoesNotThrowAsync (() => torrentCreator.CreateAsync ("name", files, CancellationToken.None));
         }
 
         [Test]
-        public void CreateMultiTest()
+        public async Task CreateMultiTest()
         {
             foreach (var v in announces)
                 creator.Announces.Add (v);
 
-            BEncodedDictionary dict = creator.Create("TorrentName", files);
+            BEncodedDictionary dict = await creator.CreateAsync("TorrentName", files);
             Torrent torrent = Torrent.Load(dict);
 
             VerifyCommonParts(torrent);
@@ -107,15 +104,15 @@ namespace MonoTorrent.Common
                 Assert.IsTrue(files.Exists (delegate(TorrentFile f) { return f.Equals(torrent.Files[i]); }));
         }
         [Test]
-        public void NoTrackersTest()
+        public async Task NoTrackersTest()
         {
-            BEncodedDictionary dict = creator.Create("TorrentName", files);
+            BEncodedDictionary dict = await creator.CreateAsync("TorrentName", files);
             Torrent t = Torrent.Load(dict);
             Assert.AreEqual(0, t.AnnounceUrls.Count, "#1");
         }
 
         [Test]
-        public void CreateSingleTest()
+        public async Task CreateSingleTest()
         {
             foreach (var v in announces)
                 creator.Announces.Add (v);
@@ -125,7 +122,7 @@ namespace MonoTorrent.Common
                                             files[0].StartPieceIndex,
                                             files[0].EndPieceIndex);
 
-            BEncodedDictionary dict = creator.Create(f.Path, new List<TorrentFile> (new TorrentFile[] { f }));
+            BEncodedDictionary dict = await creator.CreateAsync(f.Path, new List<TorrentFile> (new TorrentFile[] { f }));
             Torrent torrent = Torrent.Load(dict);
 
             VerifyCommonParts(torrent);
@@ -149,7 +146,7 @@ namespace MonoTorrent.Common
         }
 
         [Test]
-        public void LargeMultiTorrent()
+        public async Task LargeMultiTorrent()
         {
             string name1 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
             string name2 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
@@ -164,7 +161,7 @@ namespace MonoTorrent.Common
                 new TorrentFile(name5, (long)(PieceLength * 600.94), 15, 15),
             });
 
-            Torrent torrent = Torrent.Load (creator.Create("BaseDir", files));
+            Torrent torrent = Torrent.Load (await creator.CreateAsync("BaseDir", files));
             Assert.AreEqual(5, torrent.Files.Length, "#1");
             Assert.AreEqual(name1, torrent.Files[0].Path, "#2");
             Assert.AreEqual(name2, torrent.Files[1].Path, "#3");

--- a/src/MonoTorrent/MonoTorrent.Client.PieceWriters/DiskWriter.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PieceWriters/DiskWriter.cs
@@ -86,7 +86,9 @@ namespace MonoTorrent.Client.PieceWriters
             Stream s = GetStream(file, FileAccess.Read);
             if (s.Length < offset + count)
                 return 0;
-            s.Seek(offset, SeekOrigin.Begin);
+
+            if (s.Position != offset)
+                s.Seek(offset, SeekOrigin.Begin);
             return s.Read(buffer, bufferOffset, count);
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
@@ -105,13 +105,13 @@ namespace MonoTorrent.Client
                     Directory.CreateDirectory (Path.GetDirectoryName(file.FullPath));
                     NtfsSparseFile.CreateSparse (file.FullPath, file.Length);
                 }
-                s = new TorrentFileStream (file, FileMode.OpenOrCreate, access, FileShare.Read);
+                s = new TorrentFileStream (file, FileMode.OpenOrCreate, access, FileShare.ReadWrite);
 
                 // Ensure that we truncate existing files which are too large
                 if (s.Length > file.Length) {
                     if (!s.CanWrite) {
                         s.Close();
-                        s = new TorrentFileStream(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                        s = new TorrentFileStream(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
                     }
                     s.SetLength(file.Length);
                 }

--- a/src/MonoTorrent/MonoTorrent/Synchronizer.cs
+++ b/src/MonoTorrent/MonoTorrent/Synchronizer.cs
@@ -1,0 +1,64 @@
+﻿//
+// Synchronizer.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System.Collections.Generic;
+using ReusableTasks;
+
+namespace MonoTorrent
+{
+    class Synchronizer
+    {
+        public static Queue<Synchronizer> CreateLinked (int count)
+        {
+            var all = new List<Synchronizer> ();
+            for (int i = 0; i < count; i++)
+                all.Add (new Synchronizer ());
+
+            all [0].Self.SetResult (true);
+
+            for (int i = 0; i < count; i++) {
+                all [i].PreviousNode = all [(i - 1 + count) % count];
+                all [i].NextNode = all [(i + 1 + count) % count];
+            }
+            return new Queue<Synchronizer> (all);
+        }
+
+        public ReusableTaskCompletionSource<bool> Next => NextNode.Self;
+        public ReusableTaskCompletionSource<bool> Self { get; } = new ReusableTaskCompletionSource<bool> ();
+
+        Synchronizer PreviousNode;
+        Synchronizer NextNode;
+
+        public void Disconnect ()
+        {
+            PreviousNode.NextNode = NextNode;
+            NextNode.PreviousNode = PreviousNode;
+        }
+    }
+}


### PR DESCRIPTION
After running `sudo purge` to simulate an uncached/unbuffered run on my Mac, the timings for a 2GB file are:
```
Total:             00:00:15.7296231

ReadAll - Dequeue: 00:00:14.5927816
ReadAll - Read:    00:00:00.9673251
ReadAll - Enqueue: 00:00:00.0158462

Hashing - Dequeue: 00:00:00.0528362
Hashing - Hashing: 00:00:15.3869370
Hashing - Enqueue: 00:00:00.1013505
```

A cached/buffered run looks like:
```
Total:             00:00:14.4390740

ReadAll - Dequeue: 00:00:13.9951740
ReadAll - Read:    00:00:00.4241805
ReadAll - Enqueue: 00:00:00.0078499

Hashing - Dequeue: 00:00:00.0075505
Hashing - Hashing: 00:00:14.3528456
Hashing - Enqueue: 00:00:00.0734906
```
The vast majority of the time is in the SHA1 hashing when we read from the disk in 256kB chunks using one thread.