### PR TITLE
Improve the endgame switcher logic

### DIFF
--- a/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGamePickerTests.cs
@@ -197,45 +197,5 @@ namespace MonoTorrent.Client.PiecePicking
             picker.Initialise(bitfield, torrentData, pieces);
             Assert.IsTrue (picker.Requests.All (t => !t.Block.Received), "#1");
         }
-
-        [Test]
-        public void SmallTorrent_BeginEndgameImmediately ()
-        {
-            var data = new TestTorrentData {
-                Files = new [] { new TorrentFile ("foo", Piece.BlockSize * 3 * 2) },
-                PieceLength = Piece.BlockSize * 2,
-                Size = Piece.BlockSize * 3 * 2
-            };
-
-            var standard = new StandardPicker ();
-            var endgame = new EndGamePicker ();
-            var switcher = new EndGameSwitcher (standard, endgame, null);
-
-            switcher.Initialise (new BitField (3), data, Enumerable.Empty<Piece> ());
-            Assert.IsNotNull (standard.PickPiece (id, new BitField (3).SetAll (true), Array.Empty<IPieceRequester> ()), "#1");
-            Assert.IsNotNull (endgame.PickPiece (id, new BitField (3).SetAll (true), Array.Empty<IPieceRequester> ()), "#2");
-        }
-
-        [Test]
-        public void SmallTorrent_BeginEndgameImmediately_WithActiveRequests ()
-        {
-            var data = new TestTorrentData {
-                Files = new [] { new TorrentFile ("foo", Piece.BlockSize * 3 * 2) },
-                PieceLength = Piece.BlockSize * 2,
-                Size = Piece.BlockSize * 3 * 2
-            };
-
-            var standard = new StandardPicker ();
-            var endgame = new EndGamePicker ();
-            var switcher = new EndGameSwitcher (standard, endgame, null);
-
-            var piece =  new Piece  (0, data.PieceLength, data.Size);
-            piece.Blocks [0].CreateRequest (id);
-
-            switcher.Initialise (new BitField (3), data, new [] { piece });
-            Assert.AreEqual (1, endgame.ExportActiveRequests ().Count, "#3");
-            Assert.AreEqual (0, standard.ExportActiveRequests ().Count, "#4");
-        }
-
     }
 }

--- a/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MonoTorrent.Client.PiecePicking;
+using NUnit.Framework;
+
+namespace MonoTorrent.Client.PiecePicking
+{
+    class EndGameSwitcherTests
+    {
+        class TestTorrentData : ITorrentData
+        {
+            public BitField Bitfield { get; set; }
+            public PeerId Seeder { get; set; }
+
+            public TorrentFile[] Files { get; set; }
+            public int PieceLength { get; set; }
+            public long Size { get; set; }
+        }
+
+        TestTorrentData LargeTorrent;
+        TestTorrentData SmallTorrent;
+
+        EndGamePicker Endgame;
+        StandardPicker Standard;
+        EndGameSwitcher Switcher;
+
+        [SetUp]
+        public void Setup ()
+        {
+            SmallTorrent = new TestTorrentData {
+                Files = new[] { new TorrentFile("foo", length: Piece.BlockSize * 2 * 3, startIndex: 0, endIndex: 2) },
+                PieceLength = Piece.BlockSize * 2,
+                Size = Piece.BlockSize * 2 * 3,
+
+                Bitfield = new BitField(3),
+                Seeder = PeerId.CreateNull(3, seeder: true)
+            };
+
+            LargeTorrent = new TestTorrentData {
+
+                Files = new[] { new TorrentFile("foo", length: Piece.BlockSize * 2 * 300, startIndex: 0, endIndex: 299) },
+                PieceLength = Piece.BlockSize * 2,
+                Size = Piece.BlockSize * 2 * 300,
+
+                Bitfield = new BitField(300),
+                Seeder = PeerId.CreateNull(300, seeder: true)
+            };
+
+            LargeTorrent.Seeder.IsChoking = SmallTorrent.Seeder.IsChoking = false;
+            LargeTorrent.Seeder.AmInterested = SmallTorrent.Seeder.AmInterested = true;
+
+            Standard = new StandardPicker();
+            Endgame = new EndGamePicker();
+            Switcher = new EndGameSwitcher(Standard, Endgame, null);
+
+        }
+
+        [Test]
+        public void SmallTorrent_InitializeSwitcher_NoExisting ()
+        {
+            Switcher.Initialise (SmallTorrent.Bitfield, SmallTorrent, Enumerable.Empty<Piece> ());
+            Assert.AreEqual (0, Endgame.ExportActiveRequests().Count, "#1");
+            Assert.AreEqual (0, Standard.ExportActiveRequests().Count, "#2");
+            Assert.AreSame(Standard, Switcher.ActivePicker, "#3");
+
+            Assert.IsNotNull (Standard.PickPiece (SmallTorrent.Seeder, SmallTorrent.Seeder.BitField, Array.Empty<IPieceRequester>()), "#4");
+            Assert.IsNotNull (Endgame.PickPiece  (SmallTorrent.Seeder, SmallTorrent.Seeder.BitField, Array.Empty<IPieceRequester>()), "#5");
+        }
+
+        [Test]
+        public void SmallTorrent_InitializeSwitcher_WithExisting ()
+        {
+            var piece = new Piece (0, SmallTorrent.PieceLength, SmallTorrent.Size);
+            piece.Blocks[0].CreateRequest (SmallTorrent.Seeder);
+
+            Switcher.Initialise (SmallTorrent.Bitfield, SmallTorrent, new[] { piece });
+            Assert.AreEqual (1, Standard.ExportActiveRequests().Count, "#1");
+            Assert.AreEqual (0, Endgame.ExportActiveRequests().Count, "#2");
+            Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
+        }
+    }
+}

--- a/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
@@ -31,32 +31,29 @@ namespace MonoTorrent.Client.PiecePicking
         [SetUp]
         public void Setup ()
         {
+            // Three pieces of length 32kb.
             SmallTorrent = new TestTorrentData {
                 Files = new[] { new TorrentFile("foo", length: Piece.BlockSize * 2 * 3, startIndex: 0, endIndex: 2) },
                 PieceLength = Piece.BlockSize * 2,
                 Size = Piece.BlockSize * 2 * 3,
 
                 Bitfield = new BitField(3),
-                Seeder = PeerId.CreateNull(3, seeder: true)
+                Seeder = PeerId.CreateNull(3, seeder: true, isChoking: false, amInterested: true)
             };
 
+            // Three hundred pieces of length 4MB.
             LargeTorrent = new TestTorrentData {
-
                 Files = new[] { new TorrentFile("foo", length: Piece.BlockSize * 2 * 300, startIndex: 0, endIndex: 299) },
-                PieceLength = Piece.BlockSize * 2,
-                Size = Piece.BlockSize * 2 * 300,
+                PieceLength = Piece.BlockSize * 256 ,
+                Size = Piece.BlockSize * 256 * 300,
 
                 Bitfield = new BitField(300),
-                Seeder = PeerId.CreateNull(300, seeder: true)
+                Seeder = PeerId.CreateNull(300, seeder: true, isChoking: false, amInterested: true)
             };
-
-            LargeTorrent.Seeder.IsChoking = SmallTorrent.Seeder.IsChoking = false;
-            LargeTorrent.Seeder.AmInterested = SmallTorrent.Seeder.AmInterested = true;
 
             Standard = new StandardPicker();
             Endgame = new EndGamePicker();
             Switcher = new EndGameSwitcher(Standard, Endgame, null);
-
         }
 
         [Test]
@@ -81,6 +78,58 @@ namespace MonoTorrent.Client.PiecePicking
             Assert.AreEqual (1, Standard.ExportActiveRequests().Count, "#1");
             Assert.AreEqual (0, Endgame.ExportActiveRequests().Count, "#2");
             Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
+        }
+
+        [Test]
+        public void SmallTorrent_RequestAll_TriggerEndgame ()
+        {
+            Switcher.Initialise (SmallTorrent.Bitfield, SmallTorrent, Enumerable.Empty<Piece> ());
+            // Pretend we have all the pieces except one.
+            SmallTorrent.Bitfield.SetAll (true).Set (0, false);
+            // When picking we should indicate there's 1 piece that we desire - the one we're missing.
+            var onePieceLeft = SmallTorrent.Bitfield.Clone ().Not ();
+
+            // Only 2 blocks should be left to be requested, so add 1 request per person.
+            var seeders = new [] {
+                PeerId.CreateNull (SmallTorrent.Bitfield.Length, seeder: true, isChoking: false, amInterested: true),
+                PeerId.CreateNull (SmallTorrent.Bitfield.Length, seeder: true, isChoking: false, amInterested: true),
+            };
+
+            foreach (var peer in seeders) {
+                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()), "#1");
+                Assert.AreEqual (1, peer.AmRequestingPiecesCount, "#2");
+                Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
+            }
+
+            // The next request *should* trigger endgame mode and give a valid request.
+            Assert.IsNotNull (Switcher.PickPiece (SmallTorrent.Seeder, onePieceLeft, Array.Empty<IPieceRequester> ()), "#4");
+            Assert.AreSame (Endgame, Switcher.ActivePicker, "#5");
+        }
+
+        [Test]
+        public void LargeTorrent_RequestAll_TriggerEndgame ()
+        {
+            Switcher.Initialise (LargeTorrent.Bitfield, LargeTorrent, Enumerable.Empty<Piece> ());
+            // Pretend we have all the pieces except one.
+            LargeTorrent.Bitfield.SetAll (true).Set (0, false);
+            // When picking we should indicate there's 1 piece that we desire - the one we're missing.
+            var onePieceLeft = LargeTorrent.Bitfield.Clone ().Not ();
+
+            // Only 2 blocks should be left to be requested, so add 1 request per person.
+            var seeders = new List<PeerId>();
+            for (int i = 0; i < LargeTorrent.PieceLength / Piece.BlockSize; i ++)
+                seeders.Add (PeerId.CreateNull (LargeTorrent.Bitfield.Length, seeder: true, isChoking: false, amInterested: true));
+
+            // 256 blocks per piece, request 1 block per peer.
+            foreach (var peer in seeders) {
+                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()), "#1");
+                Assert.AreEqual (1, peer.AmRequestingPiecesCount, "#2");
+                Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
+            }
+
+            // The final request *should* trigger endgame mode and give a valid request.
+            Assert.IsNotNull (Switcher.PickPiece (LargeTorrent.Seeder, onePieceLeft, Array.Empty<IPieceRequester> ()), "#4");
+            Assert.AreSame (Endgame, Switcher.ActivePicker, "#5");
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -48,11 +48,22 @@ namespace MonoTorrent.Client
         /// <param name="bitfieldLength"></param>
         /// <returns></returns>
         internal static PeerId CreateNull (int bitfieldLength)
+            => CreateNull (bitfieldLength, false);
+
+        /// <summary>
+        /// Creates a PeerID with a null TorrentManager and IConnection2. This is used for unit testing purposes.
+        /// The peer will have <see cref="ProcessingQueue"/>, <see cref="IsChoking"/> and <see cref="AmChoking"/>
+        /// set to true. A bitfield with all pieces set to <see langword="false"/> will be created too.
+        /// </summary>
+        /// <param name="bitfieldLength"></param>
+        /// <param name="seeder">True if the returned peer should be treated as a seeder (the bitfield will have all pieces set to 'true')</param>
+        /// <returns></returns>
+        internal static PeerId CreateNull(int bitfieldLength, bool seeder)
         {
             return new PeerId (new Peer ("null", new Uri ("ipv4://hardcodedvalue:12345"))) {
                 IsChoking = true,
                 AmChoking = true,
-                BitField = new BitField (bitfieldLength),
+                BitField = new BitField (bitfieldLength).SetAll (seeder),
                 ProcessingQueue = true
             };
         }

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -48,7 +48,7 @@ namespace MonoTorrent.Client
         /// <param name="bitfieldLength"></param>
         /// <returns></returns>
         internal static PeerId CreateNull (int bitfieldLength)
-            => CreateNull (bitfieldLength, false);
+            => CreateNull (bitfieldLength, false, true, false);
 
         /// <summary>
         /// Creates a PeerID with a null TorrentManager and IConnection2. This is used for unit testing purposes.
@@ -60,11 +60,12 @@ namespace MonoTorrent.Client
         /// <param name="isChoking"></param>
         /// <param name="amInterested"></param>
         /// <returns></returns>
-        internal static PeerId CreateNull(int bitfieldLength, bool seeder)
+        internal static PeerId CreateNull(int bitfieldLength, bool seeder, bool isChoking, bool amInterested)
         {
             return new PeerId (new Peer ("null", new Uri ("ipv4://hardcodedvalue:12345"))) {
-                IsChoking = true,
+                IsChoking = isChoking,
                 AmChoking = true,
+                AmInterested = amInterested,
                 BitField = new BitField (bitfieldLength).SetAll (seeder),
                 ProcessingQueue = true
             };

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -57,6 +57,8 @@ namespace MonoTorrent.Client
         /// </summary>
         /// <param name="bitfieldLength"></param>
         /// <param name="seeder">True if the returned peer should be treated as a seeder (the bitfield will have all pieces set to 'true')</param>
+        /// <param name="isChoking"></param>
+        /// <param name="amInterested"></param>
         /// <returns></returns>
         internal static PeerId CreateNull(int bitfieldLength, bool seeder)
         {

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
@@ -45,10 +45,7 @@ namespace MonoTorrent.Client.PiecePicking
         PiecePicker standard;
         TorrentManager torrentManager;
 
-        PiecePicker ActivePicker
-        {
-            get { return inEndgame ? endgame : standard; }
-        }
+        public PiecePicker ActivePicker => inEndgame ? endgame : standard;
 
         public EndGameSwitcher (StandardPicker standard, EndGamePicker endgame, TorrentManager torrentManager)
             : base (null)
@@ -105,11 +102,12 @@ namespace MonoTorrent.Client.PiecePicking
             this.endgameSelector = new BitField(bitfield.Length);
             this.torrentData = torrentData;
             inEndgame = false;
-            TryEnableEndgame();
 
-            // Always initialize both pickers, but we should only give the active requests to the active picker.
-            endgame.Initialise  (bitfield, torrentData, inEndgame ? requests : Enumerable.Empty<Piece> ());
-            standard.Initialise (bitfield, torrentData, inEndgame ? Enumerable.Empty<Piece> () : requests);
+            // Always initialize both pickers, but we should only give the active requests to the Standard picker.
+            // We should never *default* to endgame mode, we should always start in regular mode and enter endgame
+            // mode after we fail to pick a piece.
+            standard.Initialise (bitfield, torrentData, requests);
+            endgame.Initialise  (bitfield, torrentData, Enumerable.Empty<Piece> ());
         }
 
         public override bool IsInteresting(BitField bitfield)

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
@@ -35,7 +35,10 @@ namespace MonoTorrent.Client.PiecePicking
 {
     public class EndGameSwitcher : PiecePicker
     {
-        const int Threshold = 20;
+        /// <summary>
+        /// Allow entering endgame mode if there are fewer than 256 blocks outstanding.
+        /// </summary>
+        const int Threshold = 256;
 
         BitField bitfield;
         bool inEndgame;
@@ -47,7 +50,7 @@ namespace MonoTorrent.Client.PiecePicking
 
         public PiecePicker ActivePicker => inEndgame ? endgame : standard;
 
-        public EndGameSwitcher (StandardPicker standard, EndGamePicker endgame, TorrentManager torrentManager)
+        public EndGameSwitcher (PiecePicker standard, EndGamePicker endgame, TorrentManager torrentManager)
             : base (null)
         {
             this.standard = standard;
@@ -147,7 +150,7 @@ namespace MonoTorrent.Client.PiecePicking
             // If the total number of blocks remaining is less than Threshold, activate Endgame mode.
             int count = standard.CurrentReceivedCount ();
             int blocksPerPiece = torrentData.PieceLength / Piece.BlockSize;
-            inEndgame = Math.Max(blocksPerPiece, (endgameSelector.TrueCount * blocksPerPiece)) - count < Threshold;
+            inEndgame = Math.Max(blocksPerPiece, (endgameSelector.TrueCount * blocksPerPiece)) - count <= Threshold;
             if (inEndgame)
             {
                 endgame.Initialise(bitfield, torrentData, standard.ExportActiveRequests());

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -785,14 +785,13 @@ namespace MonoTorrent.Client
 
         internal PiecePicker CreateStandardPicker()
         {
-            PiecePicker picker;
-            if (ClientEngine.SupportsEndgameMode)
-                picker = new EndGameSwitcher(new StandardPicker(), new EndGamePicker(), this);
-            else
-                picker = new StandardPicker();
+            PiecePicker picker = new StandardPicker();
             picker = new RandomisedPicker(picker);
             picker = new RarestFirstPicker(picker);
             picker = new PriorityPicker(picker);
+
+            if (ClientEngine.SupportsEndgameMode)
+                picker = new EndGameSwitcher(picker, new EndGamePicker(), this);
 
             return picker;
         }


### PR DESCRIPTION
Begin addressing https://github.com/mono/monotorrent/issues/183. The intention is to remove the hardcoded piece counts from endgame mode and instead adjust the logic so it more dynamically enters endgame based on the download speed and proportion of pieces which are remaining.

Currently we enter endgame mode when fewer than 20 blocks are left to download . This should really be something a little more dynamic like "As soon as all blocks have been requested" or "As soon as the majority of peers which have unchoked us are not having blocks allocated to them for download".