### PR TITLE
[core] Calling 'StartAsync' twice concurrently is an error

### DIFF
--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -50,7 +50,12 @@ namespace MonoTorrent.Client
         public List<TorrentFile> FilesThatExist = new List<TorrentFile>();
         public List<TorrentFile> DoNotReadFrom = new List<TorrentFile>();
         public bool DontWrite;
-        public List<String> Paths = new List<string>();
+
+        /// <summary>
+        /// this is the list of paths we have read from
+        /// </summary>
+        public List<string> Paths = new List<string>();
+
         public int Read(TorrentFile file, long offset, byte[] buffer, int bufferOffset, int count)
         {
             if (DoNotReadFrom.Contains(file))

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -115,6 +115,7 @@ namespace MonoTorrent.Client.Modes
 
                 Manager.Peers.ClearAll ();
                 var exchangeMessage = new PeerExchangeMessage (13, peer, dotF, null);
+                Manager.Mode = mode;
                 Manager.Mode.HandleMessage (id, exchangeMessage);
 
                 var addedArgs = await peersTask.Task.WithTimeout ();

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -29,13 +29,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
-using MonoTorrent.Client.Messages;
-using MonoTorrent.Client.Messages.Libtorrent;
-using MonoTorrent.Client.Messages.Standard;
-using MonoTorrent.Client.PieceWriters;
 using NUnit.Framework;
 
 namespace MonoTorrent.Client.Modes
@@ -101,6 +96,14 @@ namespace MonoTorrent.Client.Modes
             Manager.Mode = mode;
             await mode.WaitForStartingToComplete ();
             Assert.IsInstanceOf<DownloadMode> (Manager.Mode, "#2");
+        }
+
+        [Test]
+        public void StartTwiceTest ()
+        {
+            var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);
+            Manager.Mode = mode;
+            Assert.ThrowsAsync<TorrentException> (() => Manager.StartAsync (), "#1");
         }
 
         [Test]

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -190,6 +190,7 @@ namespace MonoTorrent.Client
                 return;
 
             Disposed = true;
+            SendQueue.Clear ();
             Connection.SafeDispose ();
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -508,20 +508,22 @@ namespace MonoTorrent.Client
 
             var hashingMode = new HashingMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
             Mode = hashingMode;
+
             try {
                 await hashingMode.WaitForHashingToComplete ();
-                HashChecked = true;
-                if (autoStart) {
-                    await StartAsync ();
-                } else if (setStoppedModeWhenDone) {
-                    Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
-                }
-            } catch {
-                HashChecked = false;
-                // If the hash check was cancelled (by virtue of a new Mode being set on the TorrentManager) then
-                // we don't want to overwrite the Mode which was set.
-                if (Mode == hashingMode)
-                    Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
+                hashingMode.Token.ThrowIfCancellationRequested ();
+            } catch (OperationCanceledException) {
+                return;
+            } catch (Exception ex) {
+                TrySetError (Reason.ReadFailure, ex);
+                return;
+            }
+
+            HashChecked = true;
+            if (autoStart) {
+                await StartAsync ();
+            } else if (setStoppedModeWhenDone) {
+                Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
             }
         }
 
@@ -582,6 +584,8 @@ namespace MonoTorrent.Client
 
             if (Mode is StoppingMode)
                 throw new TorrentException("The manager cannot be restarted while it is in the Stopping state.");
+            if (Mode is StartingMode)
+                throw new TorrentException("The manager cannot be started a second time while it is already in the Starting state.");
 
             CheckRegisteredAndDisposed();
 
@@ -591,7 +595,8 @@ namespace MonoTorrent.Client
             if (State == TorrentState.Paused) {
                 Mode = new DownloadMode(this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
             } else if (Mode is HashingMode hashing && !HashChecked) {
-                hashing.Resume ();
+               if (State == TorrentState.HashingPaused)
+                    hashing.Resume ();
             } else if (!HasMetadata) {
                 StartTime = DateTime.Now;
                 Mode = new MetadataMode(this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings, torrentSave);
@@ -647,11 +652,13 @@ namespace MonoTorrent.Client
             if (State == TorrentState.Error) {
                 Error = null;
 				Mode = new StoppedMode(this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
+                Engine.Stop();
             } else if (State != TorrentState.Stopped) {
                 var stoppingMode = new StoppingMode(this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
                 Mode = stoppingMode;
                 await stoppingMode.WaitForStoppingToComplete ();
 
+                stoppingMode.Token.ThrowIfCancellationRequested ();
                 Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
                 Engine.Stop();
             }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/ErrorMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/ErrorMode.cs
@@ -33,10 +33,12 @@ namespace MonoTorrent.Client.Modes
     {
         public override TorrentState State => TorrentState.Error;
 
+        public override bool CanAcceptConnections => false;
+        public override bool CanHandleMessages => false;
+
         public ErrorMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
             : base (manager, diskManager, connectionManager, settings)
         {
-            CanAcceptConnections = false;
         }
 
         public override void Tick(int counter)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Client.Modes
             PausedCompletionSource?.TrySetResult (null);
             PausedCompletionSource = new TaskCompletionSource<object> ();
             Cancellation.Token.Register (() => PausedCompletionSource.TrySetCanceled ());
-            Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.Hashing, State));
+            Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.HashingPaused, State));
         }
 
         public void Resume ()
@@ -69,7 +69,7 @@ namespace MonoTorrent.Client.Modes
                 return;
 
             PausedCompletionSource.TrySetResult (null);
-            Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.HashingPaused, State));
+            Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.Hashing, State));
         }
 
         public async Task WaitForHashingToComplete ()

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -47,10 +47,11 @@ namespace MonoTorrent.Client.Modes
         string savePath;
         private DateTime requestTimeout;
 
-        public override bool CanHashCheck => true;
         bool HasAnnounced { get; set; }
-        public override TorrentState State => TorrentState.Metadata;
         internal MemoryStream Stream { get; set; }
+
+        public override bool CanHashCheck => true;
+        public override TorrentState State => TorrentState.Metadata;
 
         public MetadataMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings, string savePath)
             : base (manager, diskManager, connectionManager, settings)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StoppedMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StoppedMode.cs
@@ -31,13 +31,14 @@ namespace MonoTorrent.Client.Modes
 {
     class StoppedMode : Mode
     {
+        public override bool CanAcceptConnections => false;
+        public override bool CanHandleMessages => false;
         public override bool CanHashCheck => true;
         public override TorrentState State => TorrentState.Stopped;
 
         public StoppedMode(TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
             : base(manager, diskManager, connectionManager, settings)
         {
-            CanAcceptConnections = false;
         }
 
         public override void Tick (int counter)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
@@ -38,13 +38,14 @@ namespace MonoTorrent.Client.Modes
 {
     class StoppingMode : Mode
     {
+        public override bool CanAcceptConnections => false;
+        public override bool CanHandleMessages => false;
         public override bool CanHashCheck => false;
         public override TorrentState State => TorrentState.Stopping;
 
         public StoppingMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
             : base (manager, diskManager, connectionManager, settings)
         {
-            CanAcceptConnections = false;
         }
 
         public async Task WaitForStoppingToComplete ()


### PR DESCRIPTION
If a user calls 'StartAsync' and then invokes it a second time
without awaiting the original 'Task' we will now throw an
exception. This is not supported!