### PR TITLE
[core] Sanity check the bitfield length when connecting

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -224,6 +224,8 @@ namespace MonoTorrent.Client
 
             try {
                 manager.Peers.HandshakingPeers.Remove (id);
+                if (id.BitField.Length != manager.Bitfield.Length)
+                    throw new TorrentException($"The peer's bitfield was of length {id.BitField.Length} but the TorrentManager's bitfield was of length {manager.Bitfield.Length}.");
                 manager.HandlePeerConnected(id);
 
                 // If there are any pending messages, send them otherwise set the queue


### PR DESCRIPTION
Before we allow a peer to be added to the 'Connected' list,
ensure it's bitfield is of the correct length.

If we were in metadata mode before handshaking occurred and
we're in regular mode after it occurs, we could be left
with a peer with an incorrect bitfield.

Addresses https://github.com/mono/monotorrent/issues/196