### PR TITLE
[core] Don't special case peers which are handshaking

### DIFF
--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -177,7 +177,10 @@ namespace MonoTorrent.Client.Modes
             Assert.IsTrue (Peer.Connection.Connected, "#1");
             Manager.HandlePeerConnected (Peer);
             Assert.IsTrue (Peer.Connection.Connected, "#2");
-            Assert.IsTrue (Manager.Peers.ConnectedPeers.Contains (Peer), "#3");
+
+            // ConnectionManager should add the PeerId to the Connected list whenever
+            // an outgoing connection is made, or an incoming one is received.
+            Assert.IsFalse (Manager.Peers.ConnectedPeers.Contains (Peer), "#3");
         }
 
         [Test]

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -179,7 +179,7 @@ namespace MonoTorrent.Client
 
             id.ProcessingQueue = true;
             manager.Peers.ActivePeers.Add(id.Peer);
-            manager.Peers.HandshakingPeers.Add(id);
+            manager.Peers.ConnectedPeers.Add(id);
 
             try {
                 // Create a handshake message to send to the peer
@@ -223,7 +223,6 @@ namespace MonoTorrent.Client
             }
 
             try {
-                manager.Peers.HandshakingPeers.Remove (id);
                 if (id.BitField.Length != manager.Bitfield.Length)
                     throw new TorrentException($"The peer's bitfield was of length {id.BitField.Length} but the TorrentManager's bitfield was of length {manager.Bitfield.Length}.");
                 manager.HandlePeerConnected(id);
@@ -290,7 +289,6 @@ namespace MonoTorrent.Client
                     manager.UploadingTo--;
 
                 manager.Peers.ConnectedPeers.Remove (id);
-                manager.Peers.HandshakingPeers.Remove (id);
                 manager.Peers.ActivePeers.Remove(id.Peer);
 
                 // If we get our own details, this check makes sure we don't try connecting to ourselves again
@@ -358,6 +356,8 @@ namespace MonoTorrent.Client
                 Logger.Log(id.Connection, "ConnectionManager - Incoming connection fully accepted");
                 manager.Peers.AvailablePeers.Remove(id.Peer);
                 manager.Peers.ActivePeers.Add(id.Peer);
+                manager.Peers.ConnectedPeers.Add (id);
+
                 id.WhenConnected.Restart ();
                 // Baseline the time the last block was received
                 id.LastBlockReceived.Restart ();

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PeerManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PeerManager.cs
@@ -34,7 +34,6 @@ namespace MonoTorrent.Client
     public class PeerManager
     {
         internal List<PeerId> ConnectedPeers;
-        internal List<PeerId> HandshakingPeers;
         internal List<Peer> ConnectingToPeers;
 
         internal List<Peer> ActivePeers;
@@ -67,7 +66,6 @@ namespace MonoTorrent.Client
         {
             ConnectedPeers = new List<PeerId>();
             ConnectingToPeers = new List<Peer>();
-            HandshakingPeers = new List<PeerId>();
 
             ActivePeers = new List<Peer>();
             AvailablePeers = new List<Peer>();
@@ -78,7 +76,6 @@ namespace MonoTorrent.Client
         {
             ConnectedPeers.Clear ();
             ConnectingToPeers.Clear ();
-            HandshakingPeers.Clear ();
 
             ActivePeers.Clear ();
             AvailablePeers.Clear ();

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -866,7 +866,6 @@ namespace MonoTorrent.Client
         {
             // The only message sent/received so far is the Handshake message.
             // The current mode decides what additional messages need to be sent.
-            Peers.ConnectedPeers.Add (id);
             RaisePeerConnected(new PeerConnectedEventArgs(this, id));
             Mode.HandlePeerConnected(id);
         }


### PR DESCRIPTION
Once a connection has been established to a remote peer, or
an incoming connection has been received, we should add the
peer to the 'Connected' list.

This way any logic which attempts to close all open connections
will successfully close connections which are still completing
the normal bittorrent handshake.