### PR TITLE
Fixed: Prevent exception if nodes is empty string

### DIFF
--- a/src/MonoTorrent/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent/MonoTorrent/Torrent.cs
@@ -801,7 +801,8 @@ namespace MonoTorrent
                             break;
 
                         case ("nodes"):
-                            nodes = (BEncodedList)keypair.Value;
+                            if (keypair.Value.ToString().Length != 0)
+                                this.nodes = (BEncodedList)keypair.Value;
                             break;
 
                         case ("comment.utf-8"):


### PR DESCRIPTION
Reference https://github.com/Sonarr/Sonarr/commit/3bc6bf9e992b0c2e0f82591608f2037fdd313297