### PR TITLE
Fixed multifile metadatamode savepath handling, fixes mono/monotorrent#209

### DIFF
--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -583,6 +583,11 @@ namespace MonoTorrent.Client
             return new TestRig("", pieceLength, StandardWriter(), StandardTrackers(), files, metadataMode);
         }
 
+        internal static TestRig CreateMultiFile(int pieceLength, bool metadataMode)
+        {
+            return new TestRig("", pieceLength, StandardWriter(), StandardTrackers(), StandardMultiFile(), metadataMode);
+        }
+
         internal static TorrentManager CreateSingleFileManager (int torrentSize, int pieceLength)
         {
             return CreateSingleFile (torrentSize, pieceLength, false).Manager;

--- a/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentCreatorTests.cs
@@ -149,10 +149,10 @@ namespace MonoTorrent.Common
         public async Task LargeMultiTorrent()
         {
             string name1 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
-            string name2 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
-            string name3 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
-            string name4 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
-            string name5 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File1");
+            string name2 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File2");
+            string name3 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File3");
+            string name4 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File4");
+            string name5 = Path.Combine(Path.Combine("Dir1", "SDir1"), "File5");
             files = new List<TorrentFile>(new TorrentFile[] { 
                 new TorrentFile(name1, (long)(PieceLength * 200.30), 0, 1),
                 new TorrentFile(name2, (long)(PieceLength * 42000.5), 1, 3),
@@ -183,7 +183,7 @@ namespace MonoTorrent.Common
         }
 
         [Test]
-        public void TwoFilesSameDestionation ()
+        public void TwoFilesSameDestination ()
         {
             Assert.Throws<ArgumentException> (() =>
             {

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -51,10 +51,10 @@ namespace MonoTorrent.Client.Modes
         private ConnectionPair pair;
         private TestRig rig;
 
-        public async Task Setup(bool metadataMode, string metadataPath)
+        public async Task Setup(bool metadataMode, string metadataPath, bool multiFile = false)
         {
             pair = new ConnectionPair().WithTimeout ();
-            rig = TestRig.CreateMultiFile(32768, metadataMode);
+            rig = multiFile ? TestRig.CreateMultiFile(32768, metadataMode) : TestRig.CreateSingleFile(1024 * 1024 * 1024, 32768, metadataMode);
             rig.MetadataPath = metadataPath;
             rig.RecreateManager().Wait();
 
@@ -152,26 +152,42 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public async Task SingleFileSavePath()
+        {
+            var torrent = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
+            await Setup(true, torrent, multiFile: false);
+            await SendMetadataCore(torrent);
+
+            Assert.AreEqual(@"test.files", rig.Manager.Torrent.Name);
+            Assert.AreEqual(@"", rig.Manager.SavePath);
+
+            var torrentFiles = rig.Manager.Torrent.Files;
+            Assert.AreEqual(torrentFiles.Length, 1);
+            Assert.AreEqual(Path.Combine("Dir1", "File1"), torrentFiles[0].Path);
+            Assert.AreEqual(Path.Combine("Dir1", "File1"), torrentFiles[0].FullPath);
+        }
+
+        [Test]
         public async Task MultiFileSavePath()
         {
             var torrent = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup(true, torrent);
+            await Setup(true, torrent, multiFile: true);
             await SendMetadataCore(torrent);
-
-            var torrentFiles = rig.Manager.Torrent.Files;
 
             Assert.AreEqual(@"test.files", rig.Manager.Torrent.Name);
             Assert.AreEqual(@"test.files", rig.Manager.SavePath);
 
-            Assert.AreEqual(@"Dir1\File1", torrentFiles[0].Path);
-            Assert.AreEqual(@"Dir1\Dir2\File2", torrentFiles[1].Path);
+            var torrentFiles = rig.Manager.Torrent.Files;
+            Assert.AreEqual(torrentFiles.Length, 4);
+            Assert.AreEqual(Path.Combine("Dir1", "File1"), torrentFiles[0].Path);
+            Assert.AreEqual(Path.Combine("Dir1", "Dir2", "File2"), torrentFiles[1].Path);
             Assert.AreEqual(@"File3", torrentFiles[2].Path);
             Assert.AreEqual(@"File4", torrentFiles[3].Path);
 
-            Assert.AreEqual(@"test.files\Dir1\File1", torrentFiles[0].FullPath);
-            Assert.AreEqual(@"test.files\Dir1\Dir2\File2", torrentFiles[1].FullPath);
-            Assert.AreEqual(@"test.files\File3", torrentFiles[2].FullPath);
-            Assert.AreEqual(@"test.files\File4", torrentFiles[3].FullPath);
+            Assert.AreEqual(Path.Combine("test.files", "Dir1", "File1"), torrentFiles[0].FullPath);
+            Assert.AreEqual(Path.Combine("test.files", "Dir1", "Dir2", "File2"), torrentFiles[1].FullPath);
+            Assert.AreEqual(Path.Combine("test.files", "File3"), torrentFiles[2].FullPath);
+            Assert.AreEqual(Path.Combine("test.files", "File4"), torrentFiles[3].FullPath);
         }
 
         public async Task SendMetadataCore (string expectedPath)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -248,7 +248,7 @@ namespace MonoTorrent.Client
         /// <summary>
         /// The directory to download the files to
         /// </summary>
-        public string SavePath { get; private set; }
+        public string SavePath { get; internal set; }
 
         /// <summary>
         /// The settings for with this TorrentManager

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -213,6 +213,13 @@ namespace MonoTorrent.Client.Modes
             Manager.UnhashedPieces = new BitField(Manager.Torrent.Pieces.Count).SetAll (true);
 
             Manager.ChangePicker(Manager.CreateStandardPicker());
+
+            // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
+            if (Manager.Torrent.Files.Length > 1)
+            {
+                Manager.SavePath = Path.Combine(Manager.SavePath, Manager.Torrent.Name);
+            }
+
             foreach (TorrentFile file in Manager.Torrent.Files)
                 file.FullPath = Path.Combine (Manager.SavePath, file.Path);
             _ = Manager.StartAsync();


### PR DESCRIPTION
fixes mono/monotorrent#209
also fixes small typos in TorrentCreatorTests
