### PR TITLE
[core] Add path validation when loading torrents

### DIFF
--- a/src/MonoTorrent.Tests/Common/PathValidatorTests.cs
+++ b/src/MonoTorrent.Tests/Common/PathValidatorTests.cs
@@ -1,0 +1,67 @@
+﻿//
+// PathValidatorTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2020 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Common
+{
+    [TestFixture]
+    public class PathValidatorTests
+    {
+        [Test]
+        public void UnixRelative()
+        {
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate("../foo/bar.txt"));
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate("foo/../bar"));
+        }
+
+        [Test]
+        public void UnixRooted()
+        {
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate("/"));
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate("/foo"));
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate("/.."));
+        }
+
+        [Test]
+        public void WindowsRelative()
+        {
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate(@"..\foo\bar.txt"));
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate(@"test\..\bar.txt"));
+        }
+
+        [Test]
+        public void WindowsRooted ()
+        {
+            Assert.Throws<ArgumentException>(() => PathValidator.Validate(@"C:\test.txt"));
+        }
+    }
+}

--- a/src/MonoTorrent.Tests/Common/TorrentTest.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentTest.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Client;
@@ -255,6 +256,21 @@ namespace MonoTorrent.Common
 
             Assert.AreEqual(Path.Combine(Path.Combine("subfolder1", "subfolder2"), "file4.txt"), torrent.Files[3].Path);
             Assert.AreEqual(80000, torrent.Files[3].Length);
+        }
+
+        [Test]
+        public void InvalidPath()
+        {
+            var dict = torrent.ToDictionary();
+            var files = ((BEncodedDictionary)dict["info"])["files"] as BEncodedList;
+
+            var newFile = new BEncodedDictionary();
+            var path = new BEncodedList (new BEncodedString[] { "test", "..", "bar" });
+            newFile["path"] = path;
+            newFile["length"] = (BEncodedNumber)15251;
+            files.Add(newFile);
+
+            Assert.Throws<ArgumentException>(() => Torrent.Load(dict));
         }
 
         /// <summary>

--- a/src/MonoTorrent/MonoTorrent/PathValidator.cs
+++ b/src/MonoTorrent/MonoTorrent/PathValidator.cs
@@ -1,0 +1,61 @@
+﻿//
+// PathValidator.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2020 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+
+namespace MonoTorrent
+{
+    static class PathValidator
+    {
+        public static void Validate(string path)
+        {
+            // Make sure the user doesn't try to overwrite system files. Ensure
+            // that the path is relative and doesn't try to access its parent folder
+
+            // Unix rooted
+            if (path.StartsWith("/"))
+                throw new ArgumentException(string.Format("The path '{0}' cannot be an absolute path starting with '/'.", path));
+            // Windows rooted
+            if (path.Length > 1 && path[1] == ':')
+                throw new ArgumentException(string.Format("The path '{0}' cannot be an absolute path.", path));
+
+            // Embedded traversals
+            if (path.Contains("/../"))
+                throw new ArgumentException(string.Format("The path '{1}' cannot contain '{0}'.", "/../", path));
+            if (path.Contains("\\..\\"))
+                throw new ArgumentException(string.Format("The path '{1}' cannot contain '{0}'.", "\\..\\", path));
+
+            // Starting traversals
+            if (path.StartsWith("..\\"))
+                throw new ArgumentException(string.Format("The path '{1}' cannot contain '{0}'.", "..\\", path));
+            if (path.StartsWith("../"))
+                throw new ArgumentException(string.Format("The path '{1}' cannot contain '{0}'.", "../", path));
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
@@ -445,23 +445,8 @@ namespace MonoTorrent
 
         static void Validate (List <FileMapping> maps)
         {
-            // Make sure the user doesn't try to overwrite system files. Ensure
-            // that the path is relative and doesn't try to access its parent folder
-            var sepLinux = "/";
-            var sepWindows = "\\";
-            var dropLinux = "../";
-            var dropWindows = "..\\";
-            foreach (var map in maps) {
-                if (map.Destination.StartsWith (sepLinux))
-                    throw new ArgumentException ("The destination path cannot start with the '{0}' character", sepLinux);
-                if (map.Destination.StartsWith (sepWindows))
-                    throw new ArgumentException ("The destination path cannot start with the '{0}' character", sepWindows);
-
-                if (map.Destination.Contains (dropLinux))
-                    throw new ArgumentException ("The destination path cannot contain '{0}'", dropLinux);
-                if (map.Destination.Contains (dropWindows))
-                    throw new ArgumentException ("The destination path cannot contain '{0}'", dropWindows);
-            }
+            foreach (var map in maps)
+                PathValidator.Validate (map.Destination);
 
             // Ensure all the destination files are unique too. The files should already be sorted.
             for (int i = 1; i < maps.Count; i++)


### PR DESCRIPTION
Ensure path traversal attacks are prevented by disallowing
torrents with embedded path traversals. The logic is shared
between TorrentCreator and Torrent so the same validations
are performed when loading or creating torrents.