### PR TITLE
[core] Add a timeout when stopping torrents

### DIFF
--- a/src/MonoTorrent.Tests/Client/ManualTrackerManager.cs
+++ b/src/MonoTorrent.Tests/Client/ManualTrackerManager.cs
@@ -49,6 +49,8 @@ namespace MonoTorrent.Client
 
         public DateTime LastUpdated { get; }
 
+        public TimeSpan ResponseDelay { get; set; }
+
         public IList<TrackerTier> Tiers { get; } = new List<TrackerTier> ();
 
         public TimeSpan TimeSinceLastAnnounce { get; private set; }
@@ -81,10 +83,12 @@ namespace MonoTorrent.Client
         public Task Announce (ITracker tracker)
             => Announce (tracker, TorrentEvent.None);
 
-        Task Announce (ITracker tracker, TorrentEvent clientEvent)
+        async Task Announce (ITracker tracker, TorrentEvent clientEvent)
         {
+            if (ResponseDelay != TimeSpan.Zero)
+                await Task.Delay(ResponseDelay);
+
             Announces.Add (Tuple.Create (tracker, clientEvent));
-            return Task.CompletedTask;
         }
 
         public void RaiseAnnounceComplete (ITracker tracker, bool successful, IList<Peer> peers)

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
@@ -102,6 +102,19 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public async Task Announce_StoppedEvent_Timeout()
+        {
+            TrackerManager.AddTracker("http://1.1.1.1");
+            TrackerManager.ResponseDelay = TimeSpan.FromMinutes(1);
+
+            var mode = new StoppingMode(Manager, DiskManager, ConnectionManager, Settings);
+            Manager.Mode = mode;
+            await mode.WaitForStoppingToComplete(TimeSpan.FromMilliseconds(1)).WithTimeout ("Should've bailed");
+
+            Assert.AreEqual(0, TrackerManager.Announces.Count, "#1");
+        }
+
+        [Test]
         public async Task DisposeActiveConnections ()
         {
             Manager.Peers.ConnectedPeers.Add(Peer);

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -30,9 +30,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Listeners;
@@ -394,7 +396,11 @@ namespace MonoTorrent.Client
             }
         }
 
-        public async Task StartAll()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Task StartAll()
+            => StartAllAsync();
+
+        public async Task StartAllAsync()
         {
             CheckDisposed();
 
@@ -406,14 +412,31 @@ namespace MonoTorrent.Client
             await Task.WhenAll (tasks);
         }
 
-        public async Task StopAll()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Task StopAll()
+            => StopAllAsync();
+
+        /// <summary>
+        /// Stops all active <see cref="TorrentManager"/> instances.
+        /// </summary>
+        /// <returns></returns>
+        public Task StopAllAsync()
+            => StopAllAsync(Timeout.InfiniteTimeSpan);
+
+        /// <summary>
+        /// Stops all active <see cref="TorrentManager"/> instances. The final announce for each <see cref="TorrentManager"/> will be limited
+        /// to the maximum of either 2 seconds or <paramref name="timeout"/> seconds.
+        /// </summary>
+        /// <param name="timeout">The timeout for the final tracker announce.</param>
+        /// <returns></returns>
+        public async Task StopAllAsync(TimeSpan timeout)
         {
             CheckDisposed();
 
             await MainLoop;
             List<Task> tasks = new List<Task>();
             for (int i = 0; i < torrents.Count; i++)
-                tasks.Add (torrents[i].StopAsync());
+                tasks.Add (torrents[i].StopAsync(timeout));
             await Task.WhenAll(tasks);
         }
 


### PR DESCRIPTION
This allows a relatively simple override for the final announce
so that the returned task doesn't hang around forever.

This is not implemented in the best of ways. Ideally the
ITracker and ITrackerManager interfaces would be augmented
to take a CancellationToken or TimeSpan parameter to handle
cancellation/timeouts, but that would be an ABI break which
I don't want to do right now.

This approach isn't great as it doesn't actually cancel the
pending request, but it's good enough and allows people to
use the timeout functionality in a way which will be
compatible with any future changes to ITracker/ITrackerManager.